### PR TITLE
Added implementation agnostic logging to EasyMwsClient (no Log4Net dep)

### DIFF
--- a/src/EasyMWS/EasyMWS.Tests/EasyMwsClientTests.cs
+++ b/src/EasyMWS/EasyMWS.Tests/EasyMwsClientTests.cs
@@ -7,6 +7,7 @@ using MountainWarehouse.EasyMWS;
 using MountainWarehouse.EasyMWS.Data;
 using MountainWarehouse.EasyMWS.Enums;
 using MountainWarehouse.EasyMWS.Helpers;
+using MountainWarehouse.EasyMWS.Logging;
 using MountainWarehouse.EasyMWS.ReportProcessors;
 using MountainWarehouse.EasyMWS.Services;
 using MountainWarehouse.EasyMWS.WebService.MarketplaceWebService;
@@ -27,6 +28,7 @@ namespace EasyMWS.Tests
 	    private Mock<IFeedSubmissionProcessor> _feedSubmissionProcessorMock;
 		private readonly int ConfiguredMaxNumberOrReportRequestRetries = 2;
 	    private readonly int ConfiguredMaxNumberOrFeedSubmissionRetries = 2;
+	    private Mock<IEasyMwsLogger> _loggerMock;
 
 		public struct CallbackDataTest
 	    {
@@ -46,7 +48,8 @@ namespace EasyMWS.Tests
 			_marketplaceWebServiceClientMock = new Mock<IMarketplaceWebServiceClient>();
 			_requestReportProcessor = new Mock<IRequestReportProcessor>();
 			_feedSubmissionProcessorMock = new Mock<IFeedSubmissionProcessor>();
-			_easyMwsClient = new EasyMwsClient(AmazonRegion.Europe, "MerchantId", "", "", _feedSubmissionCallbackServiceMock.Object, _reportRequestCallbackServiceMock.Object, _marketplaceWebServiceClientMock.Object, _requestReportProcessor.Object, _feedSubmissionProcessorMock.Object, options);
+			_loggerMock = new Mock<IEasyMwsLogger>();
+			_easyMwsClient = new EasyMwsClient(AmazonRegion.Europe, "MerchantId", "", "", _feedSubmissionCallbackServiceMock.Object, _reportRequestCallbackServiceMock.Object, _marketplaceWebServiceClientMock.Object, _requestReportProcessor.Object, _feedSubmissionProcessorMock.Object, _loggerMock.Object, options);
 		}
 
 		#region QueueReport tests
@@ -169,7 +172,7 @@ namespace EasyMWS.Tests
 		    Assert.Throws<ArgumentNullException>(() =>
 			    _easyMwsClient = new EasyMwsClient(AmazonRegion.Europe, null, "", "",
 				    _feedSubmissionCallbackServiceMock.Object, _reportRequestCallbackServiceMock.Object,
-				    _marketplaceWebServiceClientMock.Object, _requestReportProcessor.Object, _feedSubmissionProcessorMock.Object, EasyMwsOptions.Defaults));
+				    _marketplaceWebServiceClientMock.Object, _requestReportProcessor.Object, _feedSubmissionProcessorMock.Object, _loggerMock.Object, EasyMwsOptions.Defaults));
 	    }
 
 	    [Test]
@@ -178,7 +181,7 @@ namespace EasyMWS.Tests
 		    Assert.Throws<ArgumentNullException>(() =>
 			    _easyMwsClient = new EasyMwsClient(AmazonRegion.Europe, "MerchantId", null, "",
 				    _feedSubmissionCallbackServiceMock.Object, _reportRequestCallbackServiceMock.Object,
-				    _marketplaceWebServiceClientMock.Object, _requestReportProcessor.Object, _feedSubmissionProcessorMock.Object, EasyMwsOptions.Defaults));
+				    _marketplaceWebServiceClientMock.Object, _requestReportProcessor.Object, _feedSubmissionProcessorMock.Object, _loggerMock.Object, EasyMwsOptions.Defaults));
 	    }
 
 	    [Test]
@@ -187,7 +190,7 @@ namespace EasyMWS.Tests
 		    Assert.Throws<ArgumentNullException>(() =>
 			    _easyMwsClient = new EasyMwsClient(AmazonRegion.Europe, "MerchantId", "", null,
 				    _feedSubmissionCallbackServiceMock.Object, _reportRequestCallbackServiceMock.Object,
-				    _marketplaceWebServiceClientMock.Object, _requestReportProcessor.Object, _feedSubmissionProcessorMock.Object, EasyMwsOptions.Defaults));
+				    _marketplaceWebServiceClientMock.Object, _requestReportProcessor.Object, _feedSubmissionProcessorMock.Object, _loggerMock.Object, EasyMwsOptions.Defaults));
 	    }
 
 		[Test]

--- a/src/EasyMWS/EasyMWS.Tests/Logging/EasyMwsClientLoggingTest.cs
+++ b/src/EasyMWS/EasyMWS.Tests/Logging/EasyMwsClientLoggingTest.cs
@@ -1,0 +1,43 @@
+﻿using MountainWarehouse.EasyMWS;
+using MountainWarehouse.EasyMWS.Helpers;
+using MountainWarehouse.EasyMWS.Logging;
+using NUnit.Framework;
+
+namespace EasyMWS.Tests.Logging
+{
+	public class EasyMwsClientLoggingTest
+	{
+		private EasyMwsClient _easyMwsClient;
+		private IEasyMwsLogger _logger;
+
+		[SetUp]
+		public void Setup()
+		{
+			_logger = new EasyMwsLogger();
+			_easyMwsClient = new EasyMwsClient(AmazonRegion.Europe, "test", "test", "test", _logger, EasyMwsOptions.Defaults);
+		}
+
+		[Test]
+		public void IfLoggingIsEnabled_Poll_LogsAtLeastOneMessage()
+		{
+			var isAtLeastOneMessageLogged = false;
+			_logger.LogAvailable += (sender, args) => { isAtLeastOneMessageLogged = true; };
+
+			_easyMwsClient.Poll();
+
+			Assert.True(isAtLeastOneMessageLogged);
+		}
+
+		[Test]
+		public void IfLoggingIsDisabled_Poll_DoesNotLogAMessage()
+		{
+			_easyMwsClient = new EasyMwsClient(AmazonRegion.Europe, "test", "test", "test", null, EasyMwsOptions.Defaults);
+			var isAtLeastOneMessageLogged = false;
+			_logger.LogAvailable += (sender, args) => { isAtLeastOneMessageLogged = true; };
+
+			_easyMwsClient.Poll();
+
+			Assert.IsFalse(isAtLeastOneMessageLogged);
+		}
+	}
+}

--- a/src/EasyMWS/EasyMWS/Enums/LogLevel.cs
+++ b/src/EasyMWS/EasyMWS/Enums/LogLevel.cs
@@ -1,0 +1,11 @@
+﻿namespace MountainWarehouse.EasyMWS.Enums
+{
+	public enum LogLevel
+	{
+		Debug,
+		Info,
+		Warn,
+		Error,
+		Fatal
+	}
+}

--- a/src/EasyMWS/EasyMWS/Logging/EasyMwsLogger.cs
+++ b/src/EasyMWS/EasyMWS/Logging/EasyMwsLogger.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using MountainWarehouse.EasyMWS.Enums;
+
+namespace MountainWarehouse.EasyMWS.Logging
+{
+	public class EasyMwsLogger : IEasyMwsLogger
+	{
+		private readonly bool _isEnabled = false;
+
+		public EasyMwsLogger() : this(true)
+		{
+		}
+
+		internal EasyMwsLogger(bool isEnabled)
+		{
+			_isEnabled = isEnabled;
+		}
+
+		public event EventHandler<LogAvailableEventArgs> LogAvailable;
+		public void Log(LogLevel level, string message)
+		{
+			if (!_isEnabled) return;
+
+			EventHandler<LogAvailableEventArgs> handler = LogAvailable;
+			handler?.Invoke(this, new LogAvailableEventArgs(level, message));
+		}
+
+		public void Info(string message)
+		{
+			if (!_isEnabled) return;
+
+			Log(LogLevel.Info, message);
+		}
+
+		public void Warn(string message)
+		{
+			if (!_isEnabled) return;
+
+			Log(LogLevel.Warn, message);
+		}
+
+		public void Error(string message, Exception e)
+		{
+			if (!_isEnabled) return;
+
+			EventHandler<LogAvailableEventArgs> handler = LogAvailable;
+			handler?.Invoke(this, new LogAvailableEventArgs(LogLevel.Error, message, e));
+		}
+	}
+}

--- a/src/EasyMWS/EasyMWS/Logging/IEasyMwsLogger.cs
+++ b/src/EasyMWS/EasyMWS/Logging/IEasyMwsLogger.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using MountainWarehouse.EasyMWS.Enums;
+
+namespace MountainWarehouse.EasyMWS.Logging
+{
+	public interface IEasyMwsLogger
+	{
+		event EventHandler<LogAvailableEventArgs> LogAvailable;
+
+		void Log(LogLevel level, string message);
+		void Info(string message);
+		void Warn(string message);
+		void Error(string message, Exception e);
+	}
+}

--- a/src/EasyMWS/EasyMWS/Logging/LogAvailableEventArgs.cs
+++ b/src/EasyMWS/EasyMWS/Logging/LogAvailableEventArgs.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using MountainWarehouse.EasyMWS.Enums;
+
+
+namespace MountainWarehouse.EasyMWS.Logging
+{
+	public class LogAvailableEventArgs
+	{
+		public string Message { get; set; }
+		public LogLevel Level { get; set; }
+		public Exception Exception { get; set; }
+
+		public LogAvailableEventArgs(LogLevel level, string message) => (Level, Message, Exception) = (level, message, null);
+		public LogAvailableEventArgs(LogLevel level, string message, Exception exception) => (Level, Message, Exception) = (level, message, exception);
+	}
+}


### PR DESCRIPTION
In order to obtain the logs, someone that uses the EasyMwsClient, will have to provide an instance of IEasyMwsLogger (preferably EasyMwsLogger) to the client constructor, and subscribe to the  LogAvailable event exposed by the EasyMwsLogger; the event will be fired as soon as a message was logged.