### PR TITLE
When a MarketplaceWebServiceException is thrown when trying to call a...

### DIFF
--- a/src/EasyMWS/EasyMWS.Tests/Logging/EasyMwsLoggerTests.cs
+++ b/src/EasyMWS/EasyMWS.Tests/Logging/EasyMwsLoggerTests.cs
@@ -1,0 +1,219 @@
+﻿using System;
+using System.Net;
+using MountainWarehouse.EasyMWS.Enums;
+using MountainWarehouse.EasyMWS.Logging;
+using MountainWarehouse.EasyMWS.WebService.MarketplaceWebService;
+using MountainWarehouse.EasyMWS.WebService.MarketplaceWebService.Model;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace EasyMWS.Tests.Logging
+{
+    public class EasyMwsLoggerTests
+    {
+	    private string DeserializeInternalMessage(string serializedMessage)
+	    {
+		    var deserializedMessage = ((JObject)JsonConvert.DeserializeObject(serializedMessage))["Message"];
+		    return ((JValue) deserializedMessage).Value.ToString();
+
+	    }
+
+	    [Test]
+	    public void Calling_ActionThatLogsInfoWithRequestInfo_Triggers_LogAvailableEventWithExpectedArguments()
+	    {
+			var logger = new EasyMwsLogger();
+		    LogAvailableEventArgs logAvailableArgs = null;
+		    logger.LogAvailable += (sender, args) => { logAvailableArgs = args; };
+		    var testLogsPublisher = new TestEasyMwsLogPublisher(logger);
+
+			testLogsPublisher.ActionThatLogsInfoWithRequestInfo();
+
+			Assert.IsNotNull(logAvailableArgs);
+		    Assert.IsNotNull(logAvailableArgs.Message);
+
+		    var actualLogMessage = DeserializeInternalMessage(logAvailableArgs.Message);
+
+			Assert.AreEqual("testMessage_ActionThatLogsInfoWithRequestInfo", actualLogMessage);
+		    Assert.AreEqual(LogLevel.Info, logAvailableArgs.Level);
+			Assert.IsTrue(logAvailableArgs.HasRequestInfo);
+		    Assert.IsNotNull( logAvailableArgs.RequestInfo);
+			Assert.AreEqual("testTimestamp1", logAvailableArgs.RequestInfo.Timestamp);
+		    Assert.AreEqual("testRequestId1", logAvailableArgs.RequestInfo.RequestId);
+		    Assert.AreEqual(HttpStatusCode.OK, logAvailableArgs.RequestInfo.StatusCode);
+			Assert.IsNull(logAvailableArgs.RequestInfo.ErrorCode);
+		    Assert.IsNull(logAvailableArgs.RequestInfo.ErrorType);
+		}
+
+	    [Test]
+	    public void Calling_ActionThatLogsInfoWithoutRequestInfo_Triggers_LogAvailableEventWithExpectedArguments()
+	    {
+		    var logger = new EasyMwsLogger();
+		    LogAvailableEventArgs logAvailableArgs = null;
+		    logger.LogAvailable += (sender, args) => { logAvailableArgs = args; };
+		    var testLogsPublisher = new TestEasyMwsLogPublisher(logger);
+
+		    testLogsPublisher.ActionThatLogsInfoWithoutRequestInfo();
+
+		    Assert.IsNotNull(logAvailableArgs);
+		    Assert.IsNotNull(logAvailableArgs.Message);
+
+		    var actualLogMessage = DeserializeInternalMessage(logAvailableArgs.Message);
+
+		    Assert.AreEqual("testMessage_ActionThatLogsInfoWithoutRequestInfo", actualLogMessage);
+		    Assert.AreEqual(LogLevel.Info, logAvailableArgs.Level);
+		    Assert.IsFalse(logAvailableArgs.HasRequestInfo);
+		    Assert.IsNull(logAvailableArgs.RequestInfo);
+	    }
+
+	    [Test]
+	    public void Calling_ActionThatLogsWarningWithRequestInfo_Triggers_LogAvailableEventWithExpectedArguments()
+	    {
+		    var logger = new EasyMwsLogger();
+		    LogAvailableEventArgs logAvailableArgs = null;
+		    logger.LogAvailable += (sender, args) => { logAvailableArgs = args; };
+		    var testLogsPublisher = new TestEasyMwsLogPublisher(logger);
+
+		    testLogsPublisher.ActionThatLogsWarningWithRequestInfo();
+
+		    Assert.IsNotNull(logAvailableArgs);
+		    Assert.IsNotNull(logAvailableArgs.Message);
+
+		    var actualLogMessage = DeserializeInternalMessage(logAvailableArgs.Message);
+
+		    Assert.AreEqual("testMessage_ActionThatLogsWarningWithRequestInfo", actualLogMessage);
+		    Assert.AreEqual(LogLevel.Warn, logAvailableArgs.Level);
+		    Assert.IsTrue(logAvailableArgs.HasRequestInfo);
+		    Assert.IsNotNull(logAvailableArgs.RequestInfo);
+		    Assert.AreEqual("testTimestamp2", logAvailableArgs.RequestInfo.Timestamp);
+		    Assert.AreEqual("testRequestId2", logAvailableArgs.RequestInfo.RequestId);
+		    Assert.AreEqual(HttpStatusCode.Continue, logAvailableArgs.RequestInfo.StatusCode);
+		    Assert.IsNull(logAvailableArgs.RequestInfo.ErrorCode);
+		    Assert.IsNull(logAvailableArgs.RequestInfo.ErrorType);
+	    }
+
+	    [Test]
+	    public void Calling_ActionThatLogsWarningWithoutRequestInfo_Triggers_LogAvailableEventWithExpectedArguments()
+	    {
+		    var logger = new EasyMwsLogger();
+		    LogAvailableEventArgs logAvailableArgs = null;
+		    logger.LogAvailable += (sender, args) => { logAvailableArgs = args; };
+		    var testLogsPublisher = new TestEasyMwsLogPublisher(logger);
+
+		    testLogsPublisher.ActionThatLogsWarningWithoutRequestInfo();
+
+		    Assert.IsNotNull(logAvailableArgs);
+		    Assert.IsNotNull(logAvailableArgs.Message);
+
+		    var actualLogMessage = DeserializeInternalMessage(logAvailableArgs.Message);
+
+		    Assert.AreEqual("testMessage_ActionThatLogsWarningWithoutRequestInfo", actualLogMessage);
+		    Assert.AreEqual(LogLevel.Warn, logAvailableArgs.Level);
+		    Assert.IsFalse(logAvailableArgs.HasRequestInfo);
+		    Assert.IsNull(logAvailableArgs.RequestInfo);
+	    }
+
+	    [Test]
+	    public void Calling_ActionThatLogsStandardException_Triggers_LogAvailableEventWithExpectedArguments()
+	    {
+		    var logger = new EasyMwsLogger();
+		    LogAvailableEventArgs logAvailableArgs = null;
+		    logger.LogAvailable += (sender, args) => { logAvailableArgs = args; };
+		    var testLogsPublisher = new TestEasyMwsLogPublisher(logger);
+
+		    testLogsPublisher.ActionThatLogsStandardException();
+
+		    Assert.IsNotNull(logAvailableArgs);
+		    Assert.IsNotNull(logAvailableArgs.Message);
+
+		    var actualLogMessage = DeserializeInternalMessage(logAvailableArgs.Message);
+
+		    Assert.AreEqual("testMessage_ActionThatLogsStandardException", actualLogMessage);
+		    Assert.AreEqual(LogLevel.Error, logAvailableArgs.Level);
+		    Assert.IsFalse(logAvailableArgs.HasRequestInfo);
+		    Assert.IsNull(logAvailableArgs.RequestInfo);
+	    }
+
+	    [Test]
+	    public void Calling_ActionThatLogsMarketplaceWebServiceException_Triggers_LogAvailableEventWithExpectedArguments()
+	    {
+		    var logger = new EasyMwsLogger();
+		    LogAvailableEventArgs logAvailableArgs = null;
+		    logger.LogAvailable += (sender, args) => { logAvailableArgs = args; };
+		    var testLogsPublisher = new TestEasyMwsLogPublisher(logger);
+
+		    testLogsPublisher.ActionThatLogsMarketplaceWebServiceException();
+
+		    Assert.IsNotNull(logAvailableArgs);
+		    Assert.IsNotNull(logAvailableArgs.Message);
+
+		    var actualLogMessage = DeserializeInternalMessage(logAvailableArgs.Message);
+
+		    Assert.AreEqual("testMessage_ActionThatLogsMarketplaceWebServiceException", actualLogMessage);
+		    Assert.AreEqual(LogLevel.Error, logAvailableArgs.Level);
+		    Assert.IsTrue(logAvailableArgs.HasRequestInfo);
+		    Assert.IsNotNull(logAvailableArgs.RequestInfo);
+		    Assert.AreEqual("testTimestamp123", logAvailableArgs.RequestInfo.Timestamp);
+		    Assert.AreEqual("testRequestId123", logAvailableArgs.RequestInfo.RequestId);
+		    Assert.AreEqual(HttpStatusCode.Conflict, logAvailableArgs.RequestInfo.StatusCode);
+		    Assert.AreEqual("testErrorCode", logAvailableArgs.RequestInfo.ErrorCode);
+		    Assert.AreEqual("testErrorType", logAvailableArgs.RequestInfo.ErrorType);
+	    }
+	}
+
+	public class TestEasyMwsLogPublisher
+	{
+		private IEasyMwsLogger _logger;
+		public TestEasyMwsLogPublisher(IEasyMwsLogger logger)
+		{
+			_logger = logger;
+		}
+
+		public void ActionThatLogsInfoWithRequestInfo()
+		{
+			_logger.Info("testMessage_ActionThatLogsInfoWithRequestInfo", new RequestInfo("testTimestamp1", "testRequestId1", HttpStatusCode.OK));
+		}
+
+		public void ActionThatLogsInfoWithoutRequestInfo()
+		{
+			_logger.Info("testMessage_ActionThatLogsInfoWithoutRequestInfo");
+		}
+
+		public void ActionThatLogsWarningWithRequestInfo()
+		{
+			_logger.Warn("testMessage_ActionThatLogsWarningWithRequestInfo", new RequestInfo("testTimestamp2", "testRequestId2", HttpStatusCode.Continue));
+		}
+
+		public void ActionThatLogsWarningWithoutRequestInfo()
+		{
+			_logger.Warn("testMessage_ActionThatLogsWarningWithoutRequestInfo");
+		}
+
+		public void ActionThatLogsStandardException()
+		{
+			try
+			{
+				throw new AccessViolationException("test exception message");
+			}
+			catch (Exception e)
+			{
+				_logger.Error("testMessage_ActionThatLogsStandardException", e);
+			}
+		}
+
+		public void ActionThatLogsMarketplaceWebServiceException()
+		{
+			try
+			{
+				throw new MarketplaceWebServiceException("testMessage_someInternalExceptionMessage",
+					HttpStatusCode.Conflict, "testErrorCode", "testErrorType", "testRequestId123", null,
+					new ResponseHeaderMetadata("testRequestId123", null, "testTimestamp123"));
+			}
+			catch (Exception e)
+			{
+				_logger.Error("testMessage_ActionThatLogsMarketplaceWebServiceException", e);
+			}
+		}
+	}
+}
+

--- a/src/EasyMWS/EasyMWS/Logging/EasyMwsLogger.cs
+++ b/src/EasyMWS/EasyMWS/Logging/EasyMwsLogger.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using MountainWarehouse.EasyMWS.Enums;
+using MountainWarehouse.EasyMWS.WebService.MarketplaceWebService;
+using Newtonsoft.Json;
 
 namespace MountainWarehouse.EasyMWS.Logging
 {
@@ -17,34 +19,70 @@ namespace MountainWarehouse.EasyMWS.Logging
 		}
 
 		public event EventHandler<LogAvailableEventArgs> LogAvailable;
-		public void Log(LogLevel level, string message)
+		public void Log(LogLevel level, string message, RequestInfo requestInfo = null)
 		{
 			if (!_isEnabled) return;
+
+			var eventArgs =
+				new LogAvailableEventArgs(level, $"{JsonConvert.SerializeObject(new {Message = message}, Formatting.None)}");
+
+			if (requestInfo != null)
+			{
+				var messageObject = new
+				{
+					RequestInfo = requestInfo,
+					Message = message
+				};
+
+				eventArgs.Message = $"{JsonConvert.SerializeObject(messageObject, Formatting.None)}";
+				eventArgs.RequestInfo = requestInfo;
+			}
 
 			EventHandler<LogAvailableEventArgs> handler = LogAvailable;
-			handler?.Invoke(this, new LogAvailableEventArgs(level, message));
+			handler?.Invoke(this, eventArgs);
 		}
 
-		public void Info(string message)
+		public void Info(string message, RequestInfo includeRequestInfo = null)
 		{
 			if (!_isEnabled) return;
 
-			Log(LogLevel.Info, message);
+			Log(LogLevel.Info, message, includeRequestInfo);
 		}
 
-		public void Warn(string message)
+		public void Warn(string message, RequestInfo includeRequestInfo = null)
 		{
 			if (!_isEnabled) return;
 
-			Log(LogLevel.Warn, message);
+			Log(LogLevel.Warn, message, includeRequestInfo);
 		}
 
 		public void Error(string message, Exception e)
 		{
 			if (!_isEnabled) return;
 
+			var eventArgs = new LogAvailableEventArgs(LogLevel.Error, $"{JsonConvert.SerializeObject(new { Message = message }, Formatting.None)}", e);
+
+			if (e is MarketplaceWebServiceException mwsWebServiceException)
+			{
+				eventArgs.RequestInfo = new RequestInfo(
+					mwsWebServiceException.ResponseHeaderMetadata.Timestamp,
+					mwsWebServiceException.RequestId,
+					mwsWebServiceException.StatusCode,
+					mwsWebServiceException.ErrorType,
+					mwsWebServiceException.ErrorCode);
+
+				var messageObject = new
+				{
+					RequestInfo = eventArgs.RequestInfo,
+					Message = message
+				};
+
+				eventArgs.Message = $"{JsonConvert.SerializeObject(messageObject, Formatting.None)}";
+				
+			}
+
 			EventHandler<LogAvailableEventArgs> handler = LogAvailable;
-			handler?.Invoke(this, new LogAvailableEventArgs(LogLevel.Error, message, e));
+			handler?.Invoke(this, eventArgs);
 		}
 	}
 }

--- a/src/EasyMWS/EasyMWS/Logging/IEasyMwsLogger.cs
+++ b/src/EasyMWS/EasyMWS/Logging/IEasyMwsLogger.cs
@@ -7,9 +7,9 @@ namespace MountainWarehouse.EasyMWS.Logging
 	{
 		event EventHandler<LogAvailableEventArgs> LogAvailable;
 
-		void Log(LogLevel level, string message);
-		void Info(string message);
-		void Warn(string message);
+		void Log(LogLevel level, string message, RequestInfo includeRequestInfo = null);
+		void Info(string message, RequestInfo includeRequestInfo = null);
+		void Warn(string message, RequestInfo includeRequestInfo = null);
 		void Error(string message, Exception e);
 	}
 }

--- a/src/EasyMWS/EasyMWS/Logging/LogAvailableEventArgs.cs
+++ b/src/EasyMWS/EasyMWS/Logging/LogAvailableEventArgs.cs
@@ -9,8 +9,14 @@ namespace MountainWarehouse.EasyMWS.Logging
 		public string Message { get; set; }
 		public LogLevel Level { get; set; }
 		public Exception Exception { get; set; }
+		public bool HasRequestInfo => RequestInfo != null;
+		public RequestInfo RequestInfo { get; set; }
 
-		public LogAvailableEventArgs(LogLevel level, string message) => (Level, Message, Exception) = (level, message, null);
+		public LogAvailableEventArgs()
+		{
+		}
+
+		public LogAvailableEventArgs(LogLevel level, string message) => (Level, Message, Exception, RequestInfo) = (level, message, null, null);
 		public LogAvailableEventArgs(LogLevel level, string message, Exception exception) => (Level, Message, Exception) = (level, message, exception);
 	}
 }

--- a/src/EasyMWS/EasyMWS/Logging/RequestInfo.cs
+++ b/src/EasyMWS/EasyMWS/Logging/RequestInfo.cs
@@ -1,0 +1,21 @@
+﻿using System.Net;
+
+namespace MountainWarehouse.EasyMWS.Logging
+{
+    public class RequestInfo
+    {
+	    public readonly string RequestId;
+	    public readonly string Timestamp;
+	    public readonly HttpStatusCode? StatusCode;
+	    public readonly string ErrorType;
+	    public readonly string ErrorCode;
+
+		private RequestInfo()
+	    {
+	    }
+
+	    internal RequestInfo(string timestamp, string requestId,  HttpStatusCode? statusCode = null, string errorType = null, string errorCode = null)
+			=> (Timestamp, RequestId, StatusCode, ErrorType, ErrorCode) 
+			= (timestamp, requestId, statusCode, errorType, errorCode);
+    }
+}


### PR DESCRIPTION
MWS service endpoint, an error message in json format is logged, and it contains the relevant information concerning that request (MWS request timestamp and requestId, httpStatusCode, error code, etc). Additionally this information is also provided in a RequestInfo object returned along with the log message.