### PR TITLE
Removed potential cause for connection leak

### DIFF
--- a/src/EasyMWS/EasyMWS/Data/EasyMwsContext.cs
+++ b/src/EasyMWS/EasyMWS/Data/EasyMwsContext.cs
@@ -32,15 +32,10 @@ namespace MountainWarehouse.EasyMWS.Data
 			}
 		}
 
-		private string _connectionString;
+		private readonly string _connectionString;
 		public EasyMwsContext(string connectionString = null) : this()
 		{
 			_connectionString = connectionString;
-
-			if (!string.IsNullOrEmpty(connectionString))
-			{
-				Database.GetDbConnection().ConnectionString = connectionString;
-			}
 		}
 
 		protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)


### PR DESCRIPTION
https://github.com/aspnet/EntityFrameworkCore/issues/6581
https://github.com/aspnet/EntityFrameworkCore/issues/7810

whenever this GetDbConnection() would be called it should also be disposed of. therefore this way of setting the connection string is not valid.