### PR TITLE
Feature/fix potential retry logic bugs

### DIFF
--- a/src/EasyMWS/EasyMWS.Tests/EndToEnd/ReportDownloadingTests.cs
+++ b/src/EasyMWS/EasyMWS.Tests/EndToEnd/ReportDownloadingTests.cs
@@ -45,7 +45,7 @@ namespace EasyMWS.Tests.EndToEnd
 			var reportProcessor =  new ReportProcessor(_region, _merchantId, _options, _mwsClientMock.Object, _loggerMock.Object);
 
 			_easyMwsClient = new EasyMwsClient(AmazonRegion.Europe, "MerchantId", "test", "test", reportProcessor,
-				feedProcessorMock.Object, _loggerMock.Object, EasyMwsOptions.Defaults());
+				feedProcessorMock.Object, _loggerMock.Object, _options);
 		}
 
 		[TearDown]

--- a/src/EasyMWS/EasyMWS.Tests/Processors/FeedProcessorTests.cs
+++ b/src/EasyMWS/EasyMWS.Tests/Processors/FeedProcessorTests.cs
@@ -116,14 +116,14 @@ namespace EasyMWS.Tests.ReportProcessors
 			_feedProcessor.PollFeeds(_feedSubmissionServiceMock.Object);
 
 			_feedSubmissionServiceMock.Verify(
-				rrp => rrp.GetNextFromQueueOfFeedsToSubmit(It.IsAny<EasyMwsOptions>(), It.IsAny<string>(), It.IsAny<AmazonRegion>()), Times.Once);
+				rrp => rrp.GetNextFromQueueOfFeedsToSubmit( It.IsAny<string>(), It.IsAny<AmazonRegion>()), Times.Once);
 		}
 
 		[Test]
 		public void Poll_WithGetNextFeedToSubmitFromQueueReturningNull_DoesNotSubmitFeedToAmazon()
 		{
 			_feedSubmissionServiceMock
-				.Setup(rrp => rrp.GetNextFromQueueOfFeedsToSubmit(It.IsAny<EasyMwsOptions>(), It.IsAny<string>(), It.IsAny<AmazonRegion>()))
+				.Setup(rrp => rrp.GetNextFromQueueOfFeedsToSubmit(It.IsAny<string>(), It.IsAny<AmazonRegion>()))
 				.Returns((FeedSubmissionEntry) null);
 
 			_feedProcessor.PollFeeds(_feedSubmissionServiceMock.Object);
@@ -139,7 +139,7 @@ namespace EasyMWS.Tests.ReportProcessors
 			var serializedPropertiesContainer = JsonConvert.SerializeObject(propertiesContainer);
 
 			_feedSubmissionServiceMock
-				.Setup(rrp => rrp.GetNextFromQueueOfFeedsToSubmit(It.IsAny<EasyMwsOptions>(), It.IsAny<string>(), It.IsAny<AmazonRegion>()))
+				.Setup(rrp => rrp.GetNextFromQueueOfFeedsToSubmit(It.IsAny<string>(), It.IsAny<AmazonRegion>()))
 				.Returns(new FeedSubmissionEntry(serializedPropertiesContainer));
 
 			_feedProcessor.PollFeeds(_feedSubmissionServiceMock.Object);

--- a/src/EasyMWS/EasyMWS.Tests/Processors/ReportProcessorTests.cs
+++ b/src/EasyMWS/EasyMWS.Tests/Processors/ReportProcessorTests.cs
@@ -138,14 +138,14 @@ namespace EasyMWS.Tests.ReportProcessors
 			_reportProcessor.PollReports(_reportRequestServiceMock.Object);
 
 			_reportRequestServiceMock.Verify(
-				rrp => rrp.GetNextFromQueueOfReportsToRequest(It.IsAny<EasyMwsOptions>(), It.IsAny<string>(), It.IsAny<AmazonRegion>()), Times.Once);
+				rrp => rrp.GetNextFromQueueOfReportsToRequest(It.IsAny<string>(), It.IsAny<AmazonRegion>()), Times.Once);
 		}
 
 		[Test]
 		public void Poll_WithGetNonRequestedReportFromQueueReturningNull_DoesNotRequestAReportFromAmazon()
 		{
 			_reportRequestServiceMock
-				.Setup(rrp => rrp.GetNextFromQueueOfReportsToRequest(It.IsAny<EasyMwsOptions>(), It.IsAny<string>(), It.IsAny<AmazonRegion>()))
+				.Setup(rrp => rrp.GetNextFromQueueOfReportsToRequest(It.IsAny<string>(), It.IsAny<AmazonRegion>()))
 				.Returns((ReportRequestEntry) null);
 
 			_reportProcessor.PollReports(_reportRequestServiceMock.Object);
@@ -161,7 +161,7 @@ namespace EasyMWS.Tests.ReportProcessors
 			var serializedReportRequestData = JsonConvert.SerializeObject(propertiesContainer);
 
 			_reportRequestServiceMock
-				.Setup(rrp => rrp.GetNextFromQueueOfReportsToRequest(It.IsAny<EasyMwsOptions>(), It.IsAny<string>(), It.IsAny<AmazonRegion>()))
+				.Setup(rrp => rrp.GetNextFromQueueOfReportsToRequest(It.IsAny<string>(), It.IsAny<AmazonRegion>()))
 				.Returns(new ReportRequestEntry{ReportRequestData = serializedReportRequestData });
 
 			_reportProcessor.PollReports(_reportRequestServiceMock.Object);

--- a/src/EasyMWS/EasyMWS.Tests/Services/FeedSubmissionEntryServiceTests.cs
+++ b/src/EasyMWS/EasyMWS.Tests/Services/FeedSubmissionEntryServiceTests.cs
@@ -47,7 +47,7 @@ namespace EasyMWS.Tests.Services
 
 		    _feedSubmissionCallbackRepoMock = new Mock<IFeedSubmissionEntryRepository>();
 		    _feedSubmissionCallbackRepoMock.Setup(x => x.GetAll()).Returns(_feedSubmissionEntries.AsQueryable());
-		    _feedSubmissionEntryService = new FeedSubmissionEntryService(_feedSubmissionCallbackRepoMock.Object);
+		    _feedSubmissionEntryService = new FeedSubmissionEntryService(_feedSubmissionCallbackRepoMock.Object, _options);
 		}
 
 	    [Test]
@@ -103,7 +103,7 @@ namespace EasyMWS.Tests.Services
 		    _feedSubmissionEntries.Add(feedSubmissionWithNullFeedSubmissionId2);
 
 		    var feedSubmissionCallback =
-			    _feedSubmissionEntryService.GetNextFromQueueOfFeedsToSubmit(_options, _merchantId, _region);
+			    _feedSubmissionEntryService.GetNextFromQueueOfFeedsToSubmit(_merchantId, _region);
 
 		    Assert.IsNotNull(feedSubmissionCallback);
 		    Assert.AreEqual(feedSubmissionWithNullFeedSubmissionId1.Id, feedSubmissionCallback.Id);
@@ -155,7 +155,7 @@ namespace EasyMWS.Tests.Services
 			_feedSubmissionEntries.Add(feedSubmissionWithSameRegionAndMerchantId2);
 
 			var feedSubmissionCallback =
-				_feedSubmissionEntryService.GetNextFromQueueOfFeedsToSubmit(_options, _merchantId, AmazonRegion.Australia);
+				_feedSubmissionEntryService.GetNextFromQueueOfFeedsToSubmit(_merchantId, AmazonRegion.Australia);
 
 			Assert.IsNotNull(feedSubmissionCallback);
 			Assert.AreEqual(feedSubmissionWithSameRegionAndMerchantId1.Id, feedSubmissionCallback.Id);
@@ -231,7 +231,7 @@ namespace EasyMWS.Tests.Services
 			_feedSubmissionEntries.AddRange(data);
 
 			// Act
-			var listSubmittedFeeds = _feedSubmissionEntryService.GetIdsForSubmittedFeedsFromQueue(_options, _merchantId, _region);
+			var listSubmittedFeeds = _feedSubmissionEntryService.GetIdsForSubmittedFeedsFromQueue(_merchantId, _region);
 
 			// Assert
 			Assert.AreEqual(2, listSubmittedFeeds.Count());

--- a/src/EasyMWS/EasyMWS.Tests/Services/ReportRequestEntryServiceTests.cs
+++ b/src/EasyMWS/EasyMWS.Tests/Services/ReportRequestEntryServiceTests.cs
@@ -51,7 +51,7 @@ namespace EasyMWS.Tests.Services
 
 			_reportRequestCallbackReportMock = new Mock<IReportRequestEntryRepository>();
 		    _reportRequestCallbackReportMock.Setup(x => x.GetAll()).Returns(_reportRequestEntries.AsQueryable());
-			_reportRequestEntryService = new ReportRequestEntryService(_reportRequestCallbackReportMock.Object);
+			_reportRequestEntryService = new ReportRequestEntryService(_reportRequestCallbackReportMock.Object, _options);
 	    }
 
 
@@ -116,7 +116,7 @@ namespace EasyMWS.Tests.Services
 		    };
 		    _reportRequestEntries.AddRange(data);
 
-		    var result = _reportRequestEntryService.GetNextFromQueueOfReportsToDownload(_options, _merchantId, _amazonRegion);
+		    var result = _reportRequestEntryService.GetNextFromQueueOfReportsToDownload(_merchantId, _amazonRegion);
 
 		    Assert.AreEqual(4, result?.Id);
 	    }
@@ -135,7 +135,7 @@ namespace EasyMWS.Tests.Services
 		    _reportRequestEntries.Add(reportRequestWithCorrectRegion2);
 
 		    var reportRequestCallback =
-			    _reportRequestEntryService.GetNextFromQueueOfReportsToRequest(_options, _merchantId, _amazonRegion);
+			    _reportRequestEntryService.GetNextFromQueueOfReportsToRequest(_merchantId, _amazonRegion);
 
 		    Assert.AreEqual(reportRequestWithCorrectRegion1.Id, reportRequestCallback.Id);
 	    }
@@ -153,7 +153,7 @@ namespace EasyMWS.Tests.Services
 			_reportRequestEntries.Add(reportRequestWithCorrectRegion2);
 
 			var reportRequestCallback =
-				_reportRequestEntryService.GetNextFromQueueOfReportsToRequest(_options, _merchantId, _amazonRegion);
+				_reportRequestEntryService.GetNextFromQueueOfReportsToRequest(_merchantId, _amazonRegion);
 
 			Assert.AreEqual(reportRequestWithCorrectRegion1.Id, reportRequestCallback.Id);
 		}
@@ -173,7 +173,7 @@ namespace EasyMWS.Tests.Services
 			_reportRequestEntries.Add(reportRequestWithNullRequestReportId2);
 
 			var reportRequestCallback =
-				_reportRequestEntryService.GetNextFromQueueOfReportsToRequest(_options, _merchantId, _amazonRegion);
+				_reportRequestEntryService.GetNextFromQueueOfReportsToRequest(_merchantId, _amazonRegion);
 
 			Assert.AreEqual(reportRequestWithNullRequestReportId1.Id, reportRequestCallback.Id);
 		}
@@ -192,8 +192,10 @@ namespace EasyMWS.Tests.Services
 			_reportRequestEntries.Add(reportRequestWithNoRequestRetryCount1);
 			_reportRequestEntries.Add(reportRequestWithNoRequestRetryCount2);
 
+			_reportRequestEntryService = new ReportRequestEntryService(_reportRequestCallbackReportMock.Object, customOptions);
+
 			var reportRequestCallback =
-				_reportRequestEntryService.GetNextFromQueueOfReportsToRequest(customOptions, _merchantId, _amazonRegion);
+				_reportRequestEntryService.GetNextFromQueueOfReportsToRequest(_merchantId, _amazonRegion);
 
 			Assert.AreEqual(reportRequestWithNoRequestRetryCount1.Id, reportRequestCallback.Id);
 		}
@@ -212,8 +214,10 @@ namespace EasyMWS.Tests.Services
 			_reportRequestEntries.Add(reportRequestWithNoRetryPeriodComplete1);
 			_reportRequestEntries.Add(reportRequestWithNoRetryPeriodComplete2);
 
+			_reportRequestEntryService = new ReportRequestEntryService(_reportRequestCallbackReportMock.Object, customOptions);
+
 			var reportRequestCallback =
-				_reportRequestEntryService.GetNextFromQueueOfReportsToRequest(customOptions, _merchantId, _amazonRegion);
+				_reportRequestEntryService.GetNextFromQueueOfReportsToRequest(_merchantId, _amazonRegion);
 
 			Assert.AreEqual(reportRequestWithNoRetryPeriodComplete1.Id, reportRequestCallback.Id);
 		}
@@ -232,7 +236,9 @@ namespace EasyMWS.Tests.Services
 			_reportRequestEntries.Add(reportRequestWithNoRetryPeriodComplete1);
 			_reportRequestEntries.Add(reportRequestWithNoRetryPeriodComplete2);
 
-			var reportRequestCallback = _reportRequestEntryService.GetNextFromQueueOfReportsToRequest(customOptions, _merchantId, _amazonRegion);
+			_reportRequestEntryService = new ReportRequestEntryService(_reportRequestCallbackReportMock.Object, customOptions);
+
+			var reportRequestCallback = _reportRequestEntryService.GetNextFromQueueOfReportsToRequest(_merchantId, _amazonRegion);
 
 			Assert.AreEqual(reportRequestWithNoRetryPeriodComplete1.Id, reportRequestCallback.Id);
 		}
@@ -252,7 +258,9 @@ namespace EasyMWS.Tests.Services
 			_reportRequestEntries.Add(reportRequestWithNoRetryPeriodComplete1);
 			_reportRequestEntries.Add(reportRequestWithNoRetryPeriodComplete2);
 
-			var reportRequestCallback = _reportRequestEntryService.GetNextFromQueueOfReportsToRequest(customOptions, _merchantId, _amazonRegion);
+			_reportRequestEntryService = new ReportRequestEntryService(_reportRequestCallbackReportMock.Object, customOptions);
+
+			var reportRequestCallback = _reportRequestEntryService.GetNextFromQueueOfReportsToRequest(_merchantId, _amazonRegion);
 
 			Assert.AreEqual(reportRequestWithNoRetryPeriodComplete1.Id, reportRequestCallback.Id);
 		}
@@ -308,7 +316,9 @@ namespace EasyMWS.Tests.Services
 			_reportRequestEntries.Add(reportRequestWithNoRetryPeriodComplete2);
 			_reportRequestEntries.Add(reportRequestWithNoRetryPeriodComplete3);
 
-			var reportRequestCallback = _reportRequestEntryService.GetNextFromQueueOfReportsToRequest(customOptions, _merchantId, _amazonRegion);
+			_reportRequestEntryService = new ReportRequestEntryService(_reportRequestCallbackReportMock.Object, customOptions);
+
+			var reportRequestCallback = _reportRequestEntryService.GetNextFromQueueOfReportsToRequest(_merchantId, _amazonRegion);
 
 			Assert.AreEqual(reportRequestWithNoRetryPeriodComplete2.Id, reportRequestCallback.Id);
 		}

--- a/src/EasyMWS/EasyMWS/Processors/FeedProcessor.cs
+++ b/src/EasyMWS/EasyMWS/Processors/FeedProcessor.cs
@@ -59,7 +59,7 @@ namespace MountainWarehouse.EasyMWS.Processors
 
 		private void PerformCallbacksForPreviouslySubmittedFeeds(IFeedSubmissionEntryService feedSubmissionService)
 		{
-			var previouslySubmittedFeeds = feedSubmissionService.GetAllFromQueueOfFeedsReadyForCallback(_options, _merchantId, _region);
+			var previouslySubmittedFeeds = feedSubmissionService.GetAllFromQueueOfFeedsReadyForCallback(_merchantId, _region);
 
 			foreach (var feedSubmissionEntry in previouslySubmittedFeeds)
 			{
@@ -143,7 +143,7 @@ namespace MountainWarehouse.EasyMWS.Processors
 
 		public void SubmitNextFeedInQueueToAmazon(IFeedSubmissionEntryService feedSubmissionService)
 		{
-			var feedSubmission = feedSubmissionService.GetNextFromQueueOfFeedsToSubmit(_options, _merchantId, _region);
+			var feedSubmission = feedSubmissionService.GetNextFromQueueOfFeedsToSubmit(_merchantId, _region);
 
 			if (feedSubmission == null) return;
 		
@@ -152,7 +152,7 @@ namespace MountainWarehouse.EasyMWS.Processors
 
 		public void RequestFeedSubmissionStatusesFromAmazon(IFeedSubmissionEntryService feedSubmissionService)
 		{
-			var feedSubmissionIds = feedSubmissionService.GetIdsForSubmittedFeedsFromQueue(_options, _merchantId, _region).ToList();
+			var feedSubmissionIds = feedSubmissionService.GetIdsForSubmittedFeedsFromQueue(_merchantId, _region).ToList();
 
 			if (!feedSubmissionIds.Any())
 				return;
@@ -167,7 +167,7 @@ namespace MountainWarehouse.EasyMWS.Processors
 
 		public void DownloadNextFeedSubmissionResultFromAmazon(IFeedSubmissionEntryService feedSubmissionService)
 		{
-			var nextFeedWithProcessingComplete = feedSubmissionService.GetNextFromQueueOfProcessingCompleteFeeds(_options, _merchantId, _region);
+			var nextFeedWithProcessingComplete = feedSubmissionService.GetNextFromQueueOfProcessingCompleteFeeds(_merchantId, _region);
 			if (nextFeedWithProcessingComplete == null) return;
 
 			_feedSubmissionProcessor.DownloadFeedSubmissionResultFromAmazon(feedSubmissionService, nextFeedWithProcessingComplete);

--- a/src/EasyMWS/EasyMWS/Processors/ReportProcessor.cs
+++ b/src/EasyMWS/EasyMWS/Processors/ReportProcessor.cs
@@ -63,7 +63,7 @@ namespace MountainWarehouse.EasyMWS.Processors
 
 		public void DownloadNextReportInQueueFromAmazon(IReportRequestEntryService reportRequestService)
 		{
-			var reportToDownload = reportRequestService.GetNextFromQueueOfReportsToDownload(_options, _merchantId, _region);
+			var reportToDownload = reportRequestService.GetNextFromQueueOfReportsToDownload(_merchantId, _region);
 			if (reportToDownload == null) return;
 
 			_requestReportProcessor.DownloadGeneratedReportFromAmazon(reportRequestService, reportToDownload);
@@ -71,7 +71,7 @@ namespace MountainWarehouse.EasyMWS.Processors
 
 		private void PerformCallbackForPreviouslyDownloadedReports(IReportRequestEntryService reportRequestService)
 		{
-			var reportsReadyForCallback = reportRequestService.GetAllFromQueueOfReportsReadyForCallback(_options, _merchantId, _region);
+			var reportsReadyForCallback = reportRequestService.GetAllFromQueueOfReportsReadyForCallback(_merchantId, _region);
 
 			foreach (var reportEntry in reportsReadyForCallback)
 			{
@@ -153,7 +153,7 @@ namespace MountainWarehouse.EasyMWS.Processors
 
 		public void RequestNextReportInQueueFromAmazon(IReportRequestEntryService reportRequestService)
 		{
-			var reportRequest = reportRequestService.GetNextFromQueueOfReportsToRequest(_options, _merchantId, _region);
+			var reportRequest = reportRequestService.GetNextFromQueueOfReportsToRequest(_merchantId, _region);
 
 			if (reportRequest == null) return;
 

--- a/src/EasyMWS/EasyMWS/Services/FeedSubmissionEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/FeedSubmissionEntryService.cs
@@ -15,13 +15,14 @@ namespace MountainWarehouse.EasyMWS.Services
 	{
 	    private readonly IFeedSubmissionEntryRepository _feedRepo;
 	    private readonly IEasyMwsLogger _logger;
+		private readonly EasyMwsOptions _options;
 
 		internal FeedSubmissionEntryService(IFeedSubmissionEntryRepository feedSubmissionRepo, EasyMwsOptions options = null,
 			IEasyMwsLogger logger = null) : this(options, logger)
 			=> (_feedRepo) = (feedSubmissionRepo);
 
 		public FeedSubmissionEntryService(EasyMwsOptions options = null, IEasyMwsLogger logger = null) =>
-		    (_feedRepo, _logger) = (_feedRepo ?? new FeedSubmissionEntryRepository(options?.LocalDbConnectionStringOverride), logger);
+		    (_feedRepo, _logger, _options) = (_feedRepo ?? new FeedSubmissionEntryRepository(options?.LocalDbConnectionStringOverride), logger, options);
 
 	    public void Create(FeedSubmissionEntry entry) => _feedRepo.Create(entry);
 	    public void Update(FeedSubmissionEntry entry) => _feedRepo.Update(entry);
@@ -60,45 +61,45 @@ namespace MountainWarehouse.EasyMWS.Services
 		public FeedSubmissionEntry LastOrDefault() => _feedRepo.GetAll().OrderByDescending(x => x.Id).FirstOrDefault();
 		public FeedSubmissionEntry LastOrDefault(Expression<Func<FeedSubmissionEntry, bool>> predicate) => _feedRepo.GetAll().OrderByDescending(x => x.Id).FirstOrDefault(predicate);
 
-		public FeedSubmissionEntry GetNextFromQueueOfFeedsToSubmit(EasyMwsOptions options, string merchantId, AmazonRegion region) 
+		public FeedSubmissionEntry GetNextFromQueueOfFeedsToSubmit(string merchantId, AmazonRegion region) 
 			=> FirstOrDefault(fse => fse.AmazonRegion == region && fse.MerchantId == merchantId
 										&& fse.FeedSubmissionId == null
-				                        && IsFeedSubmissionRetryPeriodAwaited(options, fse));
+				                        && IsFeedSubmissionRetryPeriodAwaited(fse));
 
 
-		public IEnumerable<string> GetIdsForSubmittedFeedsFromQueue(EasyMwsOptions options, string merchantId, AmazonRegion region) 
+		public IEnumerable<string> GetIdsForSubmittedFeedsFromQueue(string merchantId, AmazonRegion region) 
 			=> Where(fse => fse.AmazonRegion == region && fse.MerchantId == merchantId
 				        && fse.FeedSubmissionId != null && fse.IsProcessingComplete == false
 			).Select(f => f.FeedSubmissionId);
 
-		public FeedSubmissionEntry GetNextFromQueueOfProcessingCompleteFeeds(EasyMwsOptions options, string merchantId, AmazonRegion region)
+		public FeedSubmissionEntry GetNextFromQueueOfProcessingCompleteFeeds(string merchantId, AmazonRegion region)
 			=> FirstOrDefault(fse => fse.AmazonRegion == region && fse.MerchantId == merchantId
 						 && fse.FeedSubmissionId != null && fse.IsProcessingComplete == true
-				         && IsProcessingReportDownloadRetryPeriodAwaited(options, fse));
+				         && IsProcessingReportDownloadRetryPeriodAwaited(fse));
 
-		public IEnumerable<FeedSubmissionEntry> GetAllFromQueueOfFeedsReadyForCallback(EasyMwsOptions options, string merchantId, AmazonRegion region)
+		public IEnumerable<FeedSubmissionEntry> GetAllFromQueueOfFeedsReadyForCallback(string merchantId, AmazonRegion region)
 			=> Where(fse => fse.AmazonRegion == region && fse.MerchantId == merchantId 
 						&& fse.Details != null && fse.Details.FeedSubmissionReport != null
-						&& IsFeedCallbackRetryPeriodAwaited(options, fse));
+						&& IsFeedCallbackRetryPeriodAwaited(fse));
 
-		private bool IsFeedCallbackRetryPeriodAwaited(EasyMwsOptions options, FeedSubmissionEntry feedSubmission)
+		private bool IsFeedCallbackRetryPeriodAwaited(FeedSubmissionEntry feedSubmission)
 			=> feedSubmission.InvokeCallbackRetryCount == 0 || (feedSubmission.InvokeCallbackRetryCount > 0 
 			&& RetryIntervalHelper.IsRetryPeriodAwaited(feedSubmission.LastSubmitted, feedSubmission.InvokeCallbackRetryCount,
-				options.InvokeCallbackRetryInterval, options.InvokeCallbackRetryInterval,
-				options.InvokeCallbackRetryPeriodType));
+				_options.InvokeCallbackRetryInterval, _options.InvokeCallbackRetryInterval,
+				_options.InvokeCallbackRetryPeriodType));
 
-		private bool IsFeedSubmissionRetryPeriodAwaited(EasyMwsOptions options, FeedSubmissionEntry feedSubmission)
+		private bool IsFeedSubmissionRetryPeriodAwaited(FeedSubmissionEntry feedSubmission)
 		=> feedSubmission.FeedSubmissionRetryCount == 0 || (feedSubmission.FeedSubmissionRetryCount > 0
 			&& RetryIntervalHelper.IsRetryPeriodAwaited(feedSubmission.LastSubmitted,
-				feedSubmission.FeedSubmissionRetryCount, options.FeedSubmissionRetryInitialDelay,
-				options.FeedSubmissionRetryInterval, options.FeedSubmissionRetryType));
+				feedSubmission.FeedSubmissionRetryCount, _options.FeedSubmissionRetryInitialDelay,
+			                                                    _options.FeedSubmissionRetryInterval, _options.FeedSubmissionRetryType));
 		
 
-		private bool IsProcessingReportDownloadRetryPeriodAwaited(EasyMwsOptions options, FeedSubmissionEntry feedSubmission)
+		private bool IsProcessingReportDownloadRetryPeriodAwaited(FeedSubmissionEntry feedSubmission)
 		=> feedSubmission.ReportDownloadRetryCount == 0 || (feedSubmission.ReportDownloadRetryCount > 0
 			&& RetryIntervalHelper.IsRetryPeriodAwaited(feedSubmission.LastSubmitted,
-				feedSubmission.ReportDownloadRetryCount, options.ReportDownloadRetryInitialDelay,
-				options.ReportDownloadRetryInterval, options.ReportDownloadRetryType));
+				feedSubmission.ReportDownloadRetryCount, _options.ReportDownloadRetryInitialDelay,
+				_options.ReportDownloadRetryInterval, _options.ReportDownloadRetryType));
 
 		public void Dispose()
 		{

--- a/src/EasyMWS/EasyMWS/Services/IFeedSubmissionEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/IFeedSubmissionEntryService.cs
@@ -24,11 +24,11 @@ namespace MountainWarehouse.EasyMWS.Services
 	    FeedSubmissionEntry LastOrDefault();
 	    FeedSubmissionEntry LastOrDefault(Expression<Func<FeedSubmissionEntry, bool>> predicate);
 
-	    FeedSubmissionEntry GetNextFromQueueOfFeedsToSubmit(EasyMwsOptions options, string merchantId, AmazonRegion region);
+	    FeedSubmissionEntry GetNextFromQueueOfFeedsToSubmit(string merchantId, AmazonRegion region);
 
-	    IEnumerable<string> GetIdsForSubmittedFeedsFromQueue(EasyMwsOptions options, string merchantId, AmazonRegion region);
+	    IEnumerable<string> GetIdsForSubmittedFeedsFromQueue(string merchantId, AmazonRegion region);
 
-	    FeedSubmissionEntry GetNextFromQueueOfProcessingCompleteFeeds(EasyMwsOptions options, string merchantId, AmazonRegion region);
-	    IEnumerable<FeedSubmissionEntry> GetAllFromQueueOfFeedsReadyForCallback(EasyMwsOptions options, string merchantId, AmazonRegion region);
+	    FeedSubmissionEntry GetNextFromQueueOfProcessingCompleteFeeds(string merchantId, AmazonRegion region);
+	    IEnumerable<FeedSubmissionEntry> GetAllFromQueueOfFeedsReadyForCallback(string merchantId, AmazonRegion region);
 	}
 }

--- a/src/EasyMWS/EasyMWS/Services/IReportRequestEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/IReportRequestEntryService.cs
@@ -27,9 +27,9 @@ namespace MountainWarehouse.EasyMWS.Services
 		ReportRequestEntry LastOrDefault();
 		ReportRequestEntry LastOrDefault(Expression<Func<ReportRequestEntry, bool>> predicate);
 
-		ReportRequestEntry GetNextFromQueueOfReportsToRequest(EasyMwsOptions options, string merchantId, AmazonRegion region);
-		ReportRequestEntry GetNextFromQueueOfReportsToDownload(EasyMwsOptions options, string merchantId, AmazonRegion region);
+		ReportRequestEntry GetNextFromQueueOfReportsToRequest(string merchantId, AmazonRegion region);
+		ReportRequestEntry GetNextFromQueueOfReportsToDownload( string merchantId, AmazonRegion region);
 		IEnumerable<string> GetAllPendingReportFromQueue(string merchantId, AmazonRegion region);
-		IEnumerable<ReportRequestEntry> GetAllFromQueueOfReportsReadyForCallback(EasyMwsOptions options, string merchantId, AmazonRegion region);
+		IEnumerable<ReportRequestEntry> GetAllFromQueueOfReportsReadyForCallback(string merchantId, AmazonRegion region);
 	}
 }

--- a/src/EasyMWS/EasyMWS/Services/ReportRequestEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/ReportRequestEntryService.cs
@@ -16,12 +16,13 @@ namespace MountainWarehouse.EasyMWS.Services
 	{
 		private readonly IReportRequestEntryRepository _reportRequestEntryRepository;
 		private readonly IEasyMwsLogger _logger;
+		private readonly EasyMwsOptions _options;
 
 		internal ReportRequestEntryService(IReportRequestEntryRepository reportRequestEntryRepository, EasyMwsOptions options = null, IEasyMwsLogger logger = null) : this(options, logger)
 			=> (_reportRequestEntryRepository) = (reportRequestEntryRepository);
 
-		internal ReportRequestEntryService(EasyMwsOptions options = null, IEasyMwsLogger logger = null) => (_reportRequestEntryRepository, _logger) =
-			(_reportRequestEntryRepository ?? new ReportRequestEntryRepository(options?.LocalDbConnectionStringOverride), logger);
+		internal ReportRequestEntryService(EasyMwsOptions options = null, IEasyMwsLogger logger = null) => (_reportRequestEntryRepository, _logger, _options) =
+			(_reportRequestEntryRepository ?? new ReportRequestEntryRepository(options?.LocalDbConnectionStringOverride), logger, options);
 
 		public void Create(ReportRequestEntry entry) => _reportRequestEntryRepository.Create(entry);
 		public async Task CreateAsync(ReportRequestEntry entry) => await _reportRequestEntryRepository.CreateAsync(entry);
@@ -60,43 +61,43 @@ namespace MountainWarehouse.EasyMWS.Services
 		public ReportRequestEntry LastOrDefault() => _reportRequestEntryRepository.GetAll().OrderByDescending(x => x.Id).FirstOrDefault();
 		public ReportRequestEntry LastOrDefault(Expression<Func<ReportRequestEntry, bool>> predicate) => _reportRequestEntryRepository.GetAll().OrderByDescending(x => x.Id).FirstOrDefault(predicate);
 
-		public ReportRequestEntry GetNextFromQueueOfReportsToRequest(EasyMwsOptions options, string merchantId, AmazonRegion region)
+		public ReportRequestEntry GetNextFromQueueOfReportsToRequest(string merchantId, AmazonRegion region)
 		=> FirstOrDefault(rre => rre.AmazonRegion == region && rre.MerchantId == merchantId
 										   && rre.RequestReportId == null
-					                       && IsReportRequestRetryPeriodAwaited(options, rre));
+					                       && IsReportRequestRetryPeriodAwaited(rre));
 
-		public ReportRequestEntry GetNextFromQueueOfReportsToDownload( EasyMwsOptions options, string merchantId, AmazonRegion region)
+		public ReportRequestEntry GetNextFromQueueOfReportsToDownload(string merchantId, AmazonRegion region)
 		=> FirstOrDefault(rre => rre.AmazonRegion == region && rre.MerchantId == merchantId
 						   && rre.RequestReportId != null && rre.GeneratedReportId != null && rre.Details == null
-					       && IsReportDownloadRetryPeriodAwaited(options, rre));
+					       && IsReportDownloadRetryPeriodAwaited(rre));
 
 		public IEnumerable<string> GetAllPendingReportFromQueue(string merchantId, AmazonRegion region)
 		=> Where(rre => rre.AmazonRegion == region && rre.MerchantId == merchantId
 								   && rre.RequestReportId != null && rre.GeneratedReportId == null)
 					.Select(r => r.RequestReportId);
 
-		public IEnumerable<ReportRequestEntry> GetAllFromQueueOfReportsReadyForCallback(EasyMwsOptions options, string merchantId, AmazonRegion region)
+		public IEnumerable<ReportRequestEntry> GetAllFromQueueOfReportsReadyForCallback(string merchantId, AmazonRegion region)
 		=> Where(rre => rre.AmazonRegion == region && rre.MerchantId == merchantId
 					       && rre.Details != null
-					       && IsReportCallbackRetryPeriodAwaited(options, rre));
+					       && IsReportCallbackRetryPeriodAwaited(rre));
 
-		private bool IsReportRequestRetryPeriodAwaited(EasyMwsOptions options, ReportRequestEntry reportEntry)
+		private bool IsReportRequestRetryPeriodAwaited(ReportRequestEntry reportEntry)
 			=> reportEntry.ReportRequestRetryCount == 0 || (reportEntry.ReportRequestRetryCount > 0
 			&& RetryIntervalHelper.IsRetryPeriodAwaited(reportEntry.LastAmazonRequestDate, reportEntry.ReportRequestRetryCount,
-				   options.ReportRequestRetryInitialDelay, options.ReportRequestRetryInterval,
-				   options.ReportRequestRetryType));
+				   _options.ReportRequestRetryInitialDelay, _options.ReportRequestRetryInterval,
+				   _options.ReportRequestRetryType));
 
-		private bool IsReportDownloadRetryPeriodAwaited(EasyMwsOptions options, ReportRequestEntry reportEntry)
+		private bool IsReportDownloadRetryPeriodAwaited(ReportRequestEntry reportEntry)
 			=> reportEntry.ReportDownloadRetryCount == 0 || (reportEntry.ReportDownloadRetryCount > 0
 			&& RetryIntervalHelper.IsRetryPeriodAwaited(reportEntry.LastAmazonRequestDate, reportEntry.ReportDownloadRetryCount,
-				   options.ReportDownloadRetryInitialDelay, options.ReportDownloadRetryInterval,
-				   options.ReportDownloadRetryType));
+				   _options.ReportDownloadRetryInitialDelay, _options.ReportDownloadRetryInterval,
+				   _options.ReportDownloadRetryType));
 
-		private bool IsReportCallbackRetryPeriodAwaited(EasyMwsOptions options, ReportRequestEntry reportEntry)
+		private bool IsReportCallbackRetryPeriodAwaited(ReportRequestEntry reportEntry)
 			=> reportEntry.InvokeCallbackRetryCount == 0 || (reportEntry.InvokeCallbackRetryCount > 0
 			   && RetryIntervalHelper.IsRetryPeriodAwaited(reportEntry.LastAmazonRequestDate, reportEntry.InvokeCallbackRetryCount,
-				   options.InvokeCallbackRetryInterval, options.InvokeCallbackRetryInterval,
-				   options.InvokeCallbackRetryPeriodType));
+				   _options.InvokeCallbackRetryInterval, _options.InvokeCallbackRetryInterval,
+				   _options.InvokeCallbackRetryPeriodType));
 
 		public void Dispose()
 		{


### PR DESCRIPTION
Handled some missing scenarios regarding the retry logic for several retry loops within both feed entry / request entry processing life-cycles.
Additionally, removed the options args from service methods, as the options already enter the object's interface through the constructor.
