### PR TITLE
Feature/db concurrency quickfix

### DIFF
--- a/src/EasyMWS/EasyMWS.Tests/Processors/FeedProcessorTests.cs
+++ b/src/EasyMWS/EasyMWS.Tests/Processors/FeedProcessorTests.cs
@@ -30,6 +30,7 @@ namespace EasyMWS.Tests.ReportProcessors
 		private static bool _called;
 		private readonly AmazonRegion _amazonRegion = AmazonRegion.Europe;
 		private readonly string _merchantId = "testMerchantId1";
+		private bool MarkEntryAsHandled = true;
 
 		[SetUp]
 		public void SetUp()
@@ -116,14 +117,14 @@ namespace EasyMWS.Tests.ReportProcessors
 			_feedProcessor.PollFeeds(_feedSubmissionServiceMock.Object);
 
 			_feedSubmissionServiceMock.Verify(
-				rrp => rrp.GetNextFromQueueOfFeedsToSubmit(It.IsAny<string>(), It.IsAny<AmazonRegion>()), Times.Once);
+				rrp => rrp.GetNextFromQueueOfFeedsToSubmit(It.IsAny<string>(), It.IsAny<AmazonRegion>(), MarkEntryAsHandled), Times.Once);
 		}
 
 		[Test]
 		public void Poll_WithGetNextFeedToSubmitFromQueueReturningNull_DoesNotSubmitFeedToAmazon()
 		{
 			_feedSubmissionServiceMock
-				.Setup(rrp => rrp.GetNextFromQueueOfFeedsToSubmit(It.IsAny<string>(), It.IsAny<AmazonRegion>()))
+				.Setup(rrp => rrp.GetNextFromQueueOfFeedsToSubmit(It.IsAny<string>(), It.IsAny<AmazonRegion>(), MarkEntryAsHandled))
 				.Returns((FeedSubmissionEntry) null);
 
 			_feedProcessor.PollFeeds(_feedSubmissionServiceMock.Object);
@@ -139,7 +140,7 @@ namespace EasyMWS.Tests.ReportProcessors
 			var serializedPropertiesContainer = JsonConvert.SerializeObject(propertiesContainer);
 
 			_feedSubmissionServiceMock
-				.Setup(rrp => rrp.GetNextFromQueueOfFeedsToSubmit(It.IsAny<string>(), It.IsAny<AmazonRegion>()))
+				.Setup(rrp => rrp.GetNextFromQueueOfFeedsToSubmit(It.IsAny<string>(), It.IsAny<AmazonRegion>(), MarkEntryAsHandled))
 				.Returns(new FeedSubmissionEntry(serializedPropertiesContainer));
 
 			_feedProcessor.PollFeeds(_feedSubmissionServiceMock.Object);

--- a/src/EasyMWS/EasyMWS.Tests/Processors/FeedSubmissionProcessorTests.cs
+++ b/src/EasyMWS/EasyMWS.Tests/Processors/FeedSubmissionProcessorTests.cs
@@ -324,7 +324,7 @@ namespace EasyMWS.Tests.Processors
 
 			_feedSubmissionProcessor.CleanUpFeedSubmissionQueue(_feedSubmissionServiceMock.Object);
 			_feedSubmissionServiceMock.Verify(x => x.Delete(It.Is<FeedSubmissionEntry>(e => e.Id == firstEntryToDelete.Id)), Times.Exactly(numberOfDeleteCalls));
-			_feedSubmissionServiceMock.Verify(x => x.SaveChanges(), Times.Once);
+			_feedSubmissionServiceMock.Verify(x => x.SaveChanges(), Times.Exactly(numberOfDeleteCalls));
 		}
 
 		[TestCase(RetryCountIsBelowConfiguredRetryCountLimitEdge, 0)]
@@ -364,7 +364,7 @@ namespace EasyMWS.Tests.Processors
 
 			_feedSubmissionProcessor.CleanUpFeedSubmissionQueue(_feedSubmissionServiceMock.Object);
 			_feedSubmissionServiceMock.Verify(x => x.Delete(It.Is<FeedSubmissionEntry>(e => e.Id == firstEntryToDelete.Id)), Times.Exactly(numberOfDeleteCalls));
-			_feedSubmissionServiceMock.Verify(x => x.SaveChanges(), Times.Once);
+			_feedSubmissionServiceMock.Verify(x => x.SaveChanges(), Times.Exactly(numberOfDeleteCalls));
 		}
 
 		[TestCase(RetryCountIsBelowConfiguredRetryCountLimitEdge, 0)]
@@ -404,7 +404,7 @@ namespace EasyMWS.Tests.Processors
 
 			_feedSubmissionProcessor.CleanUpFeedSubmissionQueue(_feedSubmissionServiceMock.Object);
 			_feedSubmissionServiceMock.Verify(x => x.Delete(It.Is<FeedSubmissionEntry>(e => e.Id == firstEntryToDelete.Id)), Times.Exactly(numberOfDeleteCalls));
-			_feedSubmissionServiceMock.Verify(x => x.SaveChanges(), Times.Once);
+			_feedSubmissionServiceMock.Verify(x => x.SaveChanges(), Times.Exactly(numberOfDeleteCalls));
 		}
 
 		[TestCase(RetryCountIsBelowConfiguredRetryCountLimitEdge, 0)]
@@ -443,7 +443,7 @@ namespace EasyMWS.Tests.Processors
 
 			_feedSubmissionProcessor.CleanUpFeedSubmissionQueue(_feedSubmissionServiceMock.Object);
 			_feedSubmissionServiceMock.Verify(x => x.Delete(It.Is<FeedSubmissionEntry>(e => e.Id == firstEntryToDelete.Id)), Times.Exactly(numberOfDeleteCalls));
-			_feedSubmissionServiceMock.Verify(x => x.SaveChanges(), Times.Once);
+			_feedSubmissionServiceMock.Verify(x => x.SaveChanges(), Times.Exactly(numberOfDeleteCalls));
 		}
 
 		[Test]

--- a/src/EasyMWS/EasyMWS.Tests/Processors/ReportProcessorTests.cs
+++ b/src/EasyMWS/EasyMWS.Tests/Processors/ReportProcessorTests.cs
@@ -28,6 +28,7 @@ namespace EasyMWS.Tests.ReportProcessors
 		private Mock<ICallbackActivator> _callbackActivatorMock;
 		private Mock<IEasyMwsLogger> _loggerMock;
 		private static bool _called;
+		private readonly bool MarkEntryAsLocked = true;
 
 		[SetUp]
 		public void SetUp()
@@ -138,14 +139,14 @@ namespace EasyMWS.Tests.ReportProcessors
 			_reportProcessor.PollReports(_reportRequestServiceMock.Object);
 
 			_reportRequestServiceMock.Verify(
-				rrp => rrp.GetNextFromQueueOfReportsToRequest(It.IsAny<string>(), It.IsAny<AmazonRegion>()), Times.Once);
+				rrp => rrp.GetNextFromQueueOfReportsToRequest(It.IsAny<string>(), It.IsAny<AmazonRegion>(), MarkEntryAsLocked), Times.Once);
 		}
 
 		[Test]
 		public void Poll_WithGetNonRequestedReportFromQueueReturningNull_DoesNotRequestAReportFromAmazon()
 		{
 			_reportRequestServiceMock
-				.Setup(rrp => rrp.GetNextFromQueueOfReportsToRequest(It.IsAny<string>(), It.IsAny<AmazonRegion>()))
+				.Setup(rrp => rrp.GetNextFromQueueOfReportsToRequest(It.IsAny<string>(), It.IsAny<AmazonRegion>(), MarkEntryAsLocked))
 				.Returns((ReportRequestEntry) null);
 
 			_reportProcessor.PollReports(_reportRequestServiceMock.Object);
@@ -161,7 +162,7 @@ namespace EasyMWS.Tests.ReportProcessors
 			var serializedReportRequestData = JsonConvert.SerializeObject(propertiesContainer);
 
 			_reportRequestServiceMock
-				.Setup(rrp => rrp.GetNextFromQueueOfReportsToRequest(It.IsAny<string>(), It.IsAny<AmazonRegion>()))
+				.Setup(rrp => rrp.GetNextFromQueueOfReportsToRequest(It.IsAny<string>(), It.IsAny<AmazonRegion>(), MarkEntryAsLocked))
 				.Returns(new ReportRequestEntry{ReportRequestData = serializedReportRequestData });
 
 			_reportProcessor.PollReports(_reportRequestServiceMock.Object);

--- a/src/EasyMWS/EasyMWS.Tests/Processors/RequestReportProcessorTests.cs
+++ b/src/EasyMWS/EasyMWS.Tests/Processors/RequestReportProcessorTests.cs
@@ -786,7 +786,7 @@ namespace EasyMWS.Tests.Processors
 
 			_requestReportProcessor.CleanupReportRequests(_reportRequestServiceMock.Object);
 			_reportRequestServiceMock.Verify(x => x.Delete(It.Is<ReportRequestEntry>(e => e.Id == firstEntryToDelete.Id)), Times.Exactly(numberOfDeleteCalls));
-			_reportRequestServiceMock.Verify(x => x.SaveChanges(), Times.Once);
+			_reportRequestServiceMock.Verify(x => x.SaveChanges(), Times.Exactly(numberOfDeleteCalls));
 		}
 
 		[TestCase(RetryCountIsBelowConfiguredRetryCountLimitEdge, 0)]
@@ -834,7 +834,7 @@ namespace EasyMWS.Tests.Processors
 
 			_requestReportProcessor.CleanupReportRequests(_reportRequestServiceMock.Object);
 			_reportRequestServiceMock.Verify(x => x.Delete(It.Is<ReportRequestEntry>(e => e.Id == firstEntryToDelete.Id)), Times.Exactly(numberOfDeleteCalls));
-			_reportRequestServiceMock.Verify(x => x.SaveChanges(), Times.Once);
+			_reportRequestServiceMock.Verify(x => x.SaveChanges(), Times.Exactly(numberOfDeleteCalls));
 		}
 
 		[TestCase(RetryCountIsBelowConfiguredRetryCountLimitEdge, 0)]
@@ -882,7 +882,7 @@ namespace EasyMWS.Tests.Processors
 
 			_requestReportProcessor.CleanupReportRequests(_reportRequestServiceMock.Object);
 			_reportRequestServiceMock.Verify(x => x.Delete(It.Is<ReportRequestEntry>(e => e.Id == firstEntryToDelete.Id)), Times.Exactly(numberOfDeleteCalls));
-			_reportRequestServiceMock.Verify(x => x.SaveChanges(), Times.Once);
+			_reportRequestServiceMock.Verify(x => x.SaveChanges(), Times.Exactly(numberOfDeleteCalls));
 		}
 
 		[TestCase(RetryCountIsBelowConfiguredRetryCountLimitEdge, 0)]
@@ -930,7 +930,7 @@ namespace EasyMWS.Tests.Processors
 
 			_requestReportProcessor.CleanupReportRequests(_reportRequestServiceMock.Object);
 			_reportRequestServiceMock.Verify(x => x.Delete(It.Is<ReportRequestEntry>(e => e.Id == firstEntryToDelete.Id)), Times.Exactly(numberOfDeleteCalls));
-			_reportRequestServiceMock.Verify(x => x.SaveChanges(), Times.Once);
+			_reportRequestServiceMock.Verify(x => x.SaveChanges(), Times.Exactly(numberOfDeleteCalls));
 		}
 
 		[Test]

--- a/src/EasyMWS/EasyMWS/Data/FeedSubmissionEntry.cs
+++ b/src/EasyMWS/EasyMWS/Data/FeedSubmissionEntry.cs
@@ -21,6 +21,7 @@ namespace MountainWarehouse.EasyMWS.Data
 
 	    [Key]
 	    public int Id { get; set; }
+		public bool IsLocked { get; set; }
 	    public int FeedSubmissionRetryCount { get; set; }
 	    public int FeedProcessingRetryCount { get; set; }
 	    public int ReportDownloadRetryCount { get; set; }

--- a/src/EasyMWS/EasyMWS/Data/ReportRequestEntry.cs
+++ b/src/EasyMWS/EasyMWS/Data/ReportRequestEntry.cs
@@ -20,7 +20,7 @@ namespace MountainWarehouse.EasyMWS.Data
 
 		[Key]
 		public int Id { get; set; }
-
+		public bool IsLocked { get; set; }
 		public int ReportRequestRetryCount { get; set; }
 		public int ReportDownloadRetryCount { get; set; }
 		public int InvokeCallbackRetryCount { get; set; }

--- a/src/EasyMWS/EasyMWS/Migrations/20180730135709_AddIsLockedColumnToEntries.Designer.cs
+++ b/src/EasyMWS/EasyMWS/Migrations/20180730135709_AddIsLockedColumnToEntries.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MountainWarehouse.EasyMWS.Data;
 
 namespace MountainWarehouse.EasyMWS.Migrations
 {
     [DbContext(typeof(EasyMwsContext))]
-    partial class EasyMwsContextModelSnapshot : ModelSnapshot
+    [Migration("20180730135709_AddIsLockedColumnToEntries")]
+    partial class AddIsLockedColumnToEntries
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/EasyMWS/EasyMWS/Migrations/20180730135709_AddIsLockedColumnToEntries.cs
+++ b/src/EasyMWS/EasyMWS/Migrations/20180730135709_AddIsLockedColumnToEntries.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace MountainWarehouse.EasyMWS.Migrations
+{
+    public partial class AddIsLockedColumnToEntries : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsLocked",
+                table: "ReportRequestEntries",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsLocked",
+                table: "FeedSubmissionEntries",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsLocked",
+                table: "ReportRequestEntries");
+
+            migrationBuilder.DropColumn(
+                name: "IsLocked",
+                table: "FeedSubmissionEntries");
+        }
+    }
+}

--- a/src/EasyMWS/EasyMWS/Processors/FeedProcessor.cs
+++ b/src/EasyMWS/EasyMWS/Processors/FeedProcessor.cs
@@ -101,6 +101,7 @@ namespace MountainWarehouse.EasyMWS.Processors
 
 				var feedSubmission = new FeedSubmissionEntry(serializedPropertiesContainer)
 				{
+					IsLocked = false,
 					AmazonRegion = _region,
 					MerchantId = _merchantId,
 					LastSubmitted = DateTime.MinValue,

--- a/src/EasyMWS/EasyMWS/Processors/FeedProcessor.cs
+++ b/src/EasyMWS/EasyMWS/Processors/FeedProcessor.cs
@@ -74,11 +74,14 @@ namespace MountainWarehouse.EasyMWS.Processors
 				catch (SqlException e)
 				{
 					_logger.Error($"Method callback failed for {feedSubmissionEntry.RegionAndTypeComputed} due to an internal error '{e.Message}'. The callback will be retried at the next poll request.", e);
+					feedSubmissionEntry.IsLocked = false;
+					feedSubmissionService.Update(feedSubmissionEntry);
 				}
 				catch (Exception e)
 				{
 					_logger.Error($"Method callback failed for {feedSubmissionEntry.RegionAndTypeComputed}. Current retry count is :{feedSubmissionEntry.FeedSubmissionRetryCount}. {e.Message}", e);
 					feedSubmissionEntry.InvokeCallbackRetryCount++;
+					feedSubmissionEntry.IsLocked = false;
 					feedSubmissionService.Update(feedSubmissionEntry);
 				}
 			}

--- a/src/EasyMWS/EasyMWS/Processors/FeedSubmissionProcessor.cs
+++ b/src/EasyMWS/EasyMWS/Processors/FeedSubmissionProcessor.cs
@@ -306,10 +306,12 @@ namespace MountainWarehouse.EasyMWS.Processors
 			{
 				foreach (var entryToDelete in entries)
 				{
+					if (!feedSubmissionService.GetAll().Any(fse => fse.Id == entryToDelete.Entry.Id)) continue;
 					feedSubmissionService.Delete(entryToDelete.Entry);
+					feedSubmissionService.SaveChanges();
+
 					_logger.Warn($"Feed submission entry {entryToDelete.Entry.RegionAndTypeComputed} deleted from queue. {entryToDelete.DeleteReason.ToString()} exceeded");
 				}
-				feedSubmissionService.SaveChanges();
 			}
 
 			entriesToDelete.AddRange(allEntriesForRegionAndMerchant.Where(fse => IsFeedSubmissionRetryCountExceeded(fse))

--- a/src/EasyMWS/EasyMWS/Processors/FeedSubmissionProcessor.cs
+++ b/src/EasyMWS/EasyMWS/Processors/FeedSubmissionProcessor.cs
@@ -127,6 +127,7 @@ namespace MountainWarehouse.EasyMWS.Processors
 				finally
 				{
 					stream.Dispose();
+					feedSubmission.IsLocked = false;
 					feedSubmissionService.SaveChanges();
 				}
 			}
@@ -289,6 +290,7 @@ namespace MountainWarehouse.EasyMWS.Processors
 			}
 			finally
 			{
+				feedSubmissionEntry.IsLocked = false;
 				feedSubmissionService.SaveChanges();
 			}
 		}

--- a/src/EasyMWS/EasyMWS/Processors/FeedSubmissionProcessor.cs
+++ b/src/EasyMWS/EasyMWS/Processors/FeedSubmissionProcessor.cs
@@ -215,6 +215,7 @@ namespace MountainWarehouse.EasyMWS.Processors
 					_logger.Info($"{genericProcessingInfo}. The feed submission operation will be retried. This feed processing status is not yet handled by EasyMws. FeedProcessingRetryCount is now '{feedSubmissionEntry.FeedProcessingRetryCount}'.");
 				}
 				feedSubmissionService.Update(feedSubmissionEntry);
+				feedSubmissionEntry.IsLocked = false;
 			}
 
 			feedSubmissionService.SaveChanges();

--- a/src/EasyMWS/EasyMWS/Processors/ReportProcessor.cs
+++ b/src/EasyMWS/EasyMWS/Processors/ReportProcessor.cs
@@ -86,11 +86,14 @@ namespace MountainWarehouse.EasyMWS.Processors
 				catch(SqlException e)
 				{
 					_logger.Error($"Method callback failed for {reportEntry.RegionAndTypeComputed} due to an internal error '{e.Message}'. The callback will be retried at the next poll request.", e);
+					reportEntry.IsLocked = false;
+					reportRequestService.Update(reportEntry);
 				}
 				catch (Exception e)
 				{
 					_logger.Error($"Method callback failed for {reportEntry.RegionAndTypeComputed}. Current retry count is :{reportEntry.InvokeCallbackRetryCount}. {e.Message}", e);
 					reportEntry.InvokeCallbackRetryCount++;
+					reportEntry.IsLocked = false;
 					reportRequestService.Update(reportEntry);
 				}
 			}

--- a/src/EasyMWS/EasyMWS/Processors/ReportProcessor.cs
+++ b/src/EasyMWS/EasyMWS/Processors/ReportProcessor.cs
@@ -113,6 +113,7 @@ namespace MountainWarehouse.EasyMWS.Processors
 
 				var reportRequest = new ReportRequestEntry(serializedPropertiesContainer)
 				{
+					IsLocked = false,
 					AmazonRegion = _region,
 					MerchantId = _merchantId,
 					LastAmazonRequestDate = DateTime.MinValue,

--- a/src/EasyMWS/EasyMWS/Processors/RequestReportProcessor.cs
+++ b/src/EasyMWS/EasyMWS/Processors/RequestReportProcessor.cs
@@ -183,21 +183,22 @@ namespace MountainWarehouse.EasyMWS.Processors
 	    {
 			foreach (var reportGenerationInfo in reportGenerationStatuses)
 			{
-				var reportGenerationCallback = reportRequestService.FirstOrDefault(rrc => rrc.RequestReportId == reportGenerationInfo.ReportRequestId && rrc.GeneratedReportId == null);
-				if (reportGenerationCallback == null) continue;
+				var reportRequestEntry = reportRequestService.FirstOrDefault(rrc => rrc.RequestReportId == reportGenerationInfo.ReportRequestId && rrc.GeneratedReportId == null);
+				if (reportRequestEntry == null) continue;
+				reportRequestEntry.IsLocked = false;
 
-				var genericProcessingInfo = $"ProcessingStatus returned by Amazon for {reportGenerationCallback.RegionAndTypeComputed} is '{reportGenerationInfo.ReportProcessingStatus}'.";
+				var genericProcessingInfo = $"ProcessingStatus returned by Amazon for {reportRequestEntry.RegionAndTypeComputed} is '{reportGenerationInfo.ReportProcessingStatus}'.";
 
 				if (reportGenerationInfo.ReportProcessingStatus == "_DONE_")
 				{
-					reportGenerationCallback.GeneratedReportId = reportGenerationInfo.GeneratedReportId;
-					reportGenerationCallback.ReportProcessRetryCount = 0;
-					reportRequestService.Update(reportGenerationCallback);
+					reportRequestEntry.GeneratedReportId = reportGenerationInfo.GeneratedReportId;
+					reportRequestEntry.ReportProcessRetryCount = 0;
+					reportRequestService.Update(reportRequestEntry);
 					_logger.Info($"{genericProcessingInfo}. The report is now ready for download.");
 				}
 				else if (reportGenerationInfo.ReportProcessingStatus == "_DONE_NO_DATA_")
 				{
-					reportRequestService.Delete(reportGenerationCallback);
+					reportRequestService.Delete(reportRequestEntry);
 					_logger.Warn($"{genericProcessingInfo}. The Report request entry will now be removed from queue.");
 				}
 				else if (reportGenerationInfo.ReportProcessingStatus == "_SUBMITTED_" 
@@ -207,19 +208,19 @@ namespace MountainWarehouse.EasyMWS.Processors
 				}
 				else if (reportGenerationInfo.ReportProcessingStatus == "_CANCELLED_")
 				{
-					reportGenerationCallback.RequestReportId = null;
-					reportGenerationCallback.GeneratedReportId = null;
-					reportGenerationCallback.ReportProcessRetryCount++;
-					reportRequestService.Update(reportGenerationCallback);
-					_logger.Warn($"{genericProcessingInfo}. The Report request will be retried. ReportProcessRetryCount is now '{reportGenerationCallback.ReportProcessRetryCount}'.");
+					reportRequestEntry.RequestReportId = null;
+					reportRequestEntry.GeneratedReportId = null;
+					reportRequestEntry.ReportProcessRetryCount++;
+					reportRequestService.Update(reportRequestEntry);
+					_logger.Warn($"{genericProcessingInfo}. The Report request will be retried. ReportProcessRetryCount is now '{reportRequestEntry.ReportProcessRetryCount}'.");
 				}
 				else
 				{
-					reportGenerationCallback.RequestReportId = null;
-					reportGenerationCallback.GeneratedReportId = null;
-					reportGenerationCallback.ReportProcessRetryCount++;
-					reportRequestService.Update(reportGenerationCallback);
-					_logger.Warn($"{genericProcessingInfo}. The Report request will be retried. This report processing status is not yet handled by EasyMws. ReportProcessRetryCount is now '{reportGenerationCallback.ReportProcessRetryCount}'.");
+					reportRequestEntry.RequestReportId = null;
+					reportRequestEntry.GeneratedReportId = null;
+					reportRequestEntry.ReportProcessRetryCount++;
+					reportRequestService.Update(reportRequestEntry);
+					_logger.Warn($"{genericProcessingInfo}. The Report request will be retried. This report processing status is not yet handled by EasyMws. ReportProcessRetryCount is now '{reportRequestEntry.ReportProcessRetryCount}'.");
 				}
 			}
 			reportRequestService.SaveChanges();

--- a/src/EasyMWS/EasyMWS/Processors/RequestReportProcessor.cs
+++ b/src/EasyMWS/EasyMWS/Processors/RequestReportProcessor.cs
@@ -99,7 +99,8 @@ namespace MountainWarehouse.EasyMWS.Processors
 			}
 		    finally
 			{
-			    reportRequestService.SaveChanges();
+				reportRequestEntry.IsLocked = false;
+				reportRequestService.SaveChanges();
 			}
 	    }
 
@@ -294,7 +295,8 @@ namespace MountainWarehouse.EasyMWS.Processors
 		    }
 		    finally
 		    {
-			    reportRequestService.SaveChanges();
+				reportRequestEntry.IsLocked = false;
+				reportRequestService.SaveChanges();
 		    }
 		}
 

--- a/src/EasyMWS/EasyMWS/Processors/RequestReportProcessor.cs
+++ b/src/EasyMWS/EasyMWS/Processors/RequestReportProcessor.cs
@@ -158,10 +158,12 @@ namespace MountainWarehouse.EasyMWS.Processors
 			{
 				foreach (var entryToDelete in entries)
 				{
+					if (!reportRequestService.GetAll().Any(rrc => rrc.Id == entryToDelete.Entry.Id)) continue;
 					reportRequestService.Delete(entryToDelete.Entry);
+					reportRequestService.SaveChanges();
+
 					_logger.Warn($"Report request entry {entryToDelete.Entry.RegionAndTypeComputed} deleted from queue. {entryToDelete.DeleteReason.ToString()} exceeded");
 				}
-				reportRequestService.SaveChanges();
 			}
 			
 			entriesToDelete.AddRange(allEntriesForRegionAndMerchant.Where(rrc => IsRequestRetryCountExceeded(rrc))

--- a/src/EasyMWS/EasyMWS/Processors/RequestReportProcessor.cs
+++ b/src/EasyMWS/EasyMWS/Processors/RequestReportProcessor.cs
@@ -34,7 +34,7 @@ namespace MountainWarehouse.EasyMWS.Processors
 
 		public void RequestReportFromAmazon(IReportRequestEntryService reportRequestService, ReportRequestEntry reportRequestEntry)
 	    {
-		    var missingInformationExceptionMessage = "Cannot request report from amazon due to missing report request information.";
+			var missingInformationExceptionMessage = "Cannot request report from amazon due to missing report request information.";
 
 			if (reportRequestEntry?.ReportRequestData == null) throw new ArgumentNullException($"{missingInformationExceptionMessage}: Report request data is missing.");
 		    if (string.IsNullOrEmpty(reportRequestEntry?.ReportType)) throw new ArgumentException($"{missingInformationExceptionMessage}: Report Type is missing.");
@@ -42,6 +42,7 @@ namespace MountainWarehouse.EasyMWS.Processors
 			var reportRequestData = reportRequestEntry.GetPropertiesContainer();
 
 			_logger.Info($"Attempting to request the next report in queue from Amazon: {reportRequestEntry.RegionAndTypeComputed}.");
+			reportRequestEntry.IsLocked = false;
 
 			var reportRequest = new RequestReportRequest
 			{
@@ -99,7 +100,6 @@ namespace MountainWarehouse.EasyMWS.Processors
 			}
 		    finally
 			{
-				reportRequestEntry.IsLocked = false;
 				reportRequestService.SaveChanges();
 			}
 	    }
@@ -228,10 +228,11 @@ namespace MountainWarehouse.EasyMWS.Processors
 
 		public void DownloadGeneratedReportFromAmazon(IReportRequestEntryService reportRequestService, ReportRequestEntry reportRequestEntry)
 	    {
-		    var missingInformationExceptionMessage = "Cannot request report from amazon due to missing report request information.";
+			var missingInformationExceptionMessage = "Cannot request report from amazon due to missing report request information.";
 			_logger.Info($"Attempting to download the next report in queue from Amazon: {reportRequestEntry.RegionAndTypeComputed}.");
+			reportRequestEntry.IsLocked = false;
 
-		    if (string.IsNullOrEmpty(reportRequestEntry?.GeneratedReportId)) throw new ArgumentException($"{missingInformationExceptionMessage}: GeneratedReportId is missing.");
+			if (string.IsNullOrEmpty(reportRequestEntry?.GeneratedReportId)) throw new ArgumentException($"{missingInformationExceptionMessage}: GeneratedReportId is missing.");
 
 			var reportResultStream = new MemoryStream();
 		    var getReportRequest = new GetReportRequest
@@ -296,7 +297,6 @@ namespace MountainWarehouse.EasyMWS.Processors
 		    }
 		    finally
 		    {
-				reportRequestEntry.IsLocked = false;
 				reportRequestService.SaveChanges();
 		    }
 		}

--- a/src/EasyMWS/EasyMWS/Services/FeedSubmissionEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/FeedSubmissionEntryService.cs
@@ -113,6 +113,7 @@ namespace MountainWarehouse.EasyMWS.Services
 			if (entry != null && markEntryAsLocked)
 			{
 				entry.IsLocked = true;
+				Update(entry);
 				SaveChanges();
 			}
 

--- a/src/EasyMWS/EasyMWS/Services/FeedSubmissionEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/FeedSubmissionEntryService.cs
@@ -80,10 +80,24 @@ namespace MountainWarehouse.EasyMWS.Services
 		}
 
 
-		public IEnumerable<string> GetIdsForSubmittedFeedsFromQueue(string merchantId, AmazonRegion region) 
-			=> Where(fse => fse.AmazonRegion == region && fse.MerchantId == merchantId
-				        && fse.FeedSubmissionId != null && fse.IsProcessingComplete == false
-			).Select(f => f.FeedSubmissionId);
+		public IEnumerable<string> GetIdsForSubmittedFeedsFromQueue(string merchantId, AmazonRegion region, bool markEntriesAsLocked = true)
+		{
+			var entries = Where(fse => fse.AmazonRegion == region && fse.MerchantId == merchantId
+						  && fse.FeedSubmissionId != null && fse.IsProcessingComplete == false);
+
+			if(entries.Any() && markEntriesAsLocked)
+			{
+				foreach (var entry in entries)
+				{
+					entry.IsLocked = true;
+				}
+				SaveChanges();
+			}
+
+			var entriesIds = entries.Select(f => f.FeedSubmissionId);
+
+			return entriesIds;
+		}
 
 		public FeedSubmissionEntry GetNextFromQueueOfProcessingCompleteFeeds(string merchantId, AmazonRegion region, bool markEntryAsLocked = true)
 		{

--- a/src/EasyMWS/EasyMWS/Services/FeedSubmissionEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/FeedSubmissionEntryService.cs
@@ -73,6 +73,7 @@ namespace MountainWarehouse.EasyMWS.Services
 			if(entry != null && markEntryAsLocked)
 			{
 				entry.IsLocked = true;
+				Update(entry);
 				SaveChanges();
 			}
 
@@ -90,6 +91,7 @@ namespace MountainWarehouse.EasyMWS.Services
 				foreach (var entry in entries)
 				{
 					entry.IsLocked = true;
+					Update(entry);
 				}
 				SaveChanges();
 			}

--- a/src/EasyMWS/EasyMWS/Services/IFeedSubmissionEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/IFeedSubmissionEntryService.cs
@@ -26,7 +26,7 @@ namespace MountainWarehouse.EasyMWS.Services
 
 	    FeedSubmissionEntry GetNextFromQueueOfFeedsToSubmit(string merchantId, AmazonRegion region, bool markEntryAsLocked = true);
 
-	    IEnumerable<string> GetIdsForSubmittedFeedsFromQueue(string merchantId, AmazonRegion region);
+	    IEnumerable<string> GetIdsForSubmittedFeedsFromQueue(string merchantId, AmazonRegion region, bool markEntriesAsLocked = true);
 
 	    FeedSubmissionEntry GetNextFromQueueOfProcessingCompleteFeeds(string merchantId, AmazonRegion region, bool markEntryAsLocked = true);
 	    IEnumerable<FeedSubmissionEntry> GetAllFromQueueOfFeedsReadyForCallback(string merchantId, AmazonRegion region);

--- a/src/EasyMWS/EasyMWS/Services/IFeedSubmissionEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/IFeedSubmissionEntryService.cs
@@ -29,6 +29,6 @@ namespace MountainWarehouse.EasyMWS.Services
 	    IEnumerable<string> GetIdsForSubmittedFeedsFromQueue(string merchantId, AmazonRegion region, bool markEntriesAsLocked = true);
 
 	    FeedSubmissionEntry GetNextFromQueueOfProcessingCompleteFeeds(string merchantId, AmazonRegion region, bool markEntryAsLocked = true);
-	    IEnumerable<FeedSubmissionEntry> GetAllFromQueueOfFeedsReadyForCallback(string merchantId, AmazonRegion region);
+	    IEnumerable<FeedSubmissionEntry> GetAllFromQueueOfFeedsReadyForCallback(string merchantId, AmazonRegion region, bool markEntriesAsLocked = true);
 	}
 }

--- a/src/EasyMWS/EasyMWS/Services/IFeedSubmissionEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/IFeedSubmissionEntryService.cs
@@ -24,11 +24,11 @@ namespace MountainWarehouse.EasyMWS.Services
 	    FeedSubmissionEntry LastOrDefault();
 	    FeedSubmissionEntry LastOrDefault(Expression<Func<FeedSubmissionEntry, bool>> predicate);
 
-	    FeedSubmissionEntry GetNextFromQueueOfFeedsToSubmit(string merchantId, AmazonRegion region);
+	    FeedSubmissionEntry GetNextFromQueueOfFeedsToSubmit(string merchantId, AmazonRegion region, bool markEntryAsLocked = true);
 
 	    IEnumerable<string> GetIdsForSubmittedFeedsFromQueue(string merchantId, AmazonRegion region);
 
-	    FeedSubmissionEntry GetNextFromQueueOfProcessingCompleteFeeds(string merchantId, AmazonRegion region);
+	    FeedSubmissionEntry GetNextFromQueueOfProcessingCompleteFeeds(string merchantId, AmazonRegion region, bool markEntryAsLocked = true);
 	    IEnumerable<FeedSubmissionEntry> GetAllFromQueueOfFeedsReadyForCallback(string merchantId, AmazonRegion region);
 	}
 }

--- a/src/EasyMWS/EasyMWS/Services/IReportRequestEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/IReportRequestEntryService.cs
@@ -27,8 +27,8 @@ namespace MountainWarehouse.EasyMWS.Services
 		ReportRequestEntry LastOrDefault();
 		ReportRequestEntry LastOrDefault(Expression<Func<ReportRequestEntry, bool>> predicate);
 
-		ReportRequestEntry GetNextFromQueueOfReportsToRequest(string merchantId, AmazonRegion region);
-		ReportRequestEntry GetNextFromQueueOfReportsToDownload(string merchantId, AmazonRegion region);
+		ReportRequestEntry GetNextFromQueueOfReportsToRequest(string merchantId, AmazonRegion region, bool markEntryAsLocked = true);
+		ReportRequestEntry GetNextFromQueueOfReportsToDownload(string merchantId, AmazonRegion region, bool markEntryAsLocked = true);
 		IEnumerable<string> GetAllPendingReportFromQueue(string merchantId, AmazonRegion region);
 		IEnumerable<ReportRequestEntry> GetAllFromQueueOfReportsReadyForCallback(string merchantId, AmazonRegion region);
 	}

--- a/src/EasyMWS/EasyMWS/Services/IReportRequestEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/IReportRequestEntryService.cs
@@ -30,6 +30,6 @@ namespace MountainWarehouse.EasyMWS.Services
 		ReportRequestEntry GetNextFromQueueOfReportsToRequest(string merchantId, AmazonRegion region, bool markEntryAsLocked = true);
 		ReportRequestEntry GetNextFromQueueOfReportsToDownload(string merchantId, AmazonRegion region, bool markEntryAsLocked = true);
 		IEnumerable<string> GetAllPendingReportFromQueue(string merchantId, AmazonRegion region, bool markEntriesAsLocked = true);
-		IEnumerable<ReportRequestEntry> GetAllFromQueueOfReportsReadyForCallback(string merchantId, AmazonRegion region);
+		IEnumerable<ReportRequestEntry> GetAllFromQueueOfReportsReadyForCallback(string merchantId, AmazonRegion region, bool markEntriesAsLocked = true);
 	}
 }

--- a/src/EasyMWS/EasyMWS/Services/IReportRequestEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/IReportRequestEntryService.cs
@@ -29,7 +29,7 @@ namespace MountainWarehouse.EasyMWS.Services
 
 		ReportRequestEntry GetNextFromQueueOfReportsToRequest(string merchantId, AmazonRegion region, bool markEntryAsLocked = true);
 		ReportRequestEntry GetNextFromQueueOfReportsToDownload(string merchantId, AmazonRegion region, bool markEntryAsLocked = true);
-		IEnumerable<string> GetAllPendingReportFromQueue(string merchantId, AmazonRegion region);
+		IEnumerable<string> GetAllPendingReportFromQueue(string merchantId, AmazonRegion region, bool markEntriesAsLocked = true);
 		IEnumerable<ReportRequestEntry> GetAllFromQueueOfReportsReadyForCallback(string merchantId, AmazonRegion region);
 	}
 }

--- a/src/EasyMWS/EasyMWS/Services/ReportRequestEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/ReportRequestEntryService.cs
@@ -67,7 +67,8 @@ namespace MountainWarehouse.EasyMWS.Services
 											 && rre.RequestReportId == null
 											 && RetryIntervalHelper.IsRetryPeriodAwaited(rre.LastAmazonRequestDate, rre.ReportRequestRetryCount,
 									   _options.ReportRequestRetryInitialDelay, _options.ReportRequestRetryInterval,
-									   _options.ReportRequestRetryType));
+									   _options.ReportRequestRetryType)
+									   && rre.IsLocked == false);
 
 			if (entry != null && markEntryAsLocked)
 			{
@@ -86,7 +87,8 @@ namespace MountainWarehouse.EasyMWS.Services
 							 && rre.RequestReportId != null && rre.GeneratedReportId != null && rre.Details == null
 							 && RetryIntervalHelper.IsRetryPeriodAwaited(rre.LastAmazonRequestDate, rre.ReportDownloadRetryCount,
 									   _options.ReportDownloadRetryInitialDelay, _options.ReportDownloadRetryInterval,
-									   _options.ReportDownloadRetryType));
+									   _options.ReportDownloadRetryType)
+									   && rre.IsLocked == false);
 
 			if (entry != null && markEntryAsLocked)
 			{
@@ -101,9 +103,10 @@ namespace MountainWarehouse.EasyMWS.Services
 		public IEnumerable<string> GetAllPendingReportFromQueue(string merchantId, AmazonRegion region, bool markEntriesAsLocked = true)
 		{
 			var entries = Where(rre => rre.AmazonRegion == region && rre.MerchantId == merchantId
-									 && rre.RequestReportId != null && rre.GeneratedReportId == null);
+									 && rre.RequestReportId != null && rre.GeneratedReportId == null && rre.IsLocked == false);
+			var entriesIds = entries.Select(r => r.RequestReportId).ToList();
 
-			if(entries.Any() && markEntriesAsLocked)
+			if (entries.Any() && markEntriesAsLocked)
 			{
 				foreach (var entry in entries)
 				{
@@ -112,8 +115,6 @@ namespace MountainWarehouse.EasyMWS.Services
 				}
 				SaveChanges();
 			}
-
-			var entriesIds = entries.Select(r => r.RequestReportId);
 
 			return entriesIds;
 		}

--- a/src/EasyMWS/EasyMWS/Services/ReportRequestEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/ReportRequestEntryService.cs
@@ -72,6 +72,7 @@ namespace MountainWarehouse.EasyMWS.Services
 			if (entry != null && markEntryAsLocked)
 			{
 				entry.IsLocked = true;
+				Update(entry);
 				SaveChanges();
 			}
 
@@ -90,6 +91,7 @@ namespace MountainWarehouse.EasyMWS.Services
 			if (entry != null && markEntryAsLocked)
 			{
 				entry.IsLocked = true;
+				Update(entry);
 				SaveChanges();
 			}
 


### PR DESCRIPTION
this is a quickfix feature implemented in order to prevent concurrency issues caused by multiple instances of EasyMws client trying to update data in the same database.