### PR TITLE
Fix memory leaks

### DIFF
--- a/src/EasyMWS/EasyMWS.Tests/EndToEnd/FeedSubmissionTests.cs
+++ b/src/EasyMWS/EasyMWS.Tests/EndToEnd/FeedSubmissionTests.cs
@@ -66,7 +66,18 @@ namespace EasyMWS.Tests.EndToEnd
 		    _dbContext.Dispose();
 	    }
 
-	    [Test]
+		[Test]
+		[Ignore("This should only be ran manually in debug mode, in order to check for potential memory leaks with MemoryProfiler.")]
+		public void Test_ContinouslyInitializingClientAndPolling_ShouldNotCauseMemoryLeaks()
+		{
+			while (true)
+			{
+				_easyMwsClient = new EasyMwsClient(AmazonRegion.Europe, "MerchantId", "test", "test", _loggerMock.Object, _options);
+				_easyMwsClient.Poll();
+			}
+		}
+
+		[Test]
 	    public void
 		    GivenQueuingReportAndPolling_WhenAllDataIsValid_TheReportIsDownloaded_AndIsReturnedInTheCallbackMethodAlongWithTheCallbackData()
 	    {

--- a/src/EasyMWS/EasyMWS.Tests/Processors/FeedSubmissionProcessorTests.cs
+++ b/src/EasyMWS/EasyMWS.Tests/Processors/FeedSubmissionProcessorTests.cs
@@ -57,12 +57,12 @@ namespace EasyMWS.Tests.Processors
 
 			_feedSubmissionServiceMock.Setup(x => x.GetAll()).Returns(_feedSubmissionCallbacks.AsQueryable());
 
-			_feedSubmissionServiceMock.Setup(x => x.Where(It.IsAny<Expression<Func<FeedSubmissionEntry, bool>>>()))
-				.Returns((Expression<Func<FeedSubmissionEntry, bool>> e) => _feedSubmissionCallbacks.AsQueryable().Where(e));
+			_feedSubmissionServiceMock.Setup(x => x.Where(It.IsAny<Func<FeedSubmissionEntry, bool>>()))
+				.Returns((Func<FeedSubmissionEntry, bool> e) => _feedSubmissionCallbacks.AsQueryable().Where(e));
 
 			_feedSubmissionServiceMock
-				.Setup(x => x.FirstOrDefault(It.IsAny<Expression<Func<FeedSubmissionEntry, bool>>>()))
-				.Returns((Expression<Func<FeedSubmissionEntry, bool>> e) =>
+				.Setup(x => x.FirstOrDefault(It.IsAny<Func<FeedSubmissionEntry, bool>>()))
+				.Returns((Func<FeedSubmissionEntry, bool> e) =>
 					_feedSubmissionCallbacks.AsQueryable().FirstOrDefault(e));
 		}
 

--- a/src/EasyMWS/EasyMWS.Tests/Processors/RequestReportProcessorTests.cs
+++ b/src/EasyMWS/EasyMWS.Tests/Processors/RequestReportProcessorTests.cs
@@ -99,8 +99,8 @@ namespace EasyMWS.Tests.Processors
 
 			var reportRequestCallbacks = _reportRequestCallbacks.AsQueryable();
 
-			_reportRequestServiceMock.Setup(x => x.Where(It.IsAny<Expression<Func<ReportRequestEntry, bool>>>()))
-				.Returns((Expression<Func<ReportRequestEntry, bool>> e) => reportRequestCallbacks.Where(e));
+			_reportRequestServiceMock.Setup(x => x.Where(It.IsAny<Func<ReportRequestEntry, bool>>()))
+				.Returns((Func<ReportRequestEntry, bool> e) => reportRequestCallbacks.Where(e));
 
 			_reportRequestServiceMock.Setup(x => x.GetAll()).Returns(reportRequestCallbacks);
 
@@ -111,8 +111,8 @@ namespace EasyMWS.Tests.Processors
 				.Returns(getReportRequestListResponse);
 
 			_reportRequestServiceMock
-				.Setup(x => x.FirstOrDefault(It.IsAny<Expression<Func<ReportRequestEntry, bool>>>()))
-				.Returns((Expression<Func<ReportRequestEntry, bool>> e) => reportRequestCallbacks.FirstOrDefault(e));
+				.Setup(x => x.FirstOrDefault(It.IsAny<Func<ReportRequestEntry, bool>>()))
+				.Returns((Func<ReportRequestEntry, bool> e) => reportRequestCallbacks.FirstOrDefault(e));
 
 			_marketplaceWebServiceClientMock.Setup(x => x.GetReport(It.IsAny<GetReportRequest>()))
 				.Returns(new GetReportResponse());

--- a/src/EasyMWS/EasyMWS/Services/FeedSubmissionEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/FeedSubmissionEntryService.cs
@@ -52,15 +52,11 @@ namespace MountainWarehouse.EasyMWS.Services
 		}
 
 		public void SaveChanges() => _feedRepo.SaveChanges();
-		public IQueryable<FeedSubmissionEntry> GetAll() => _feedRepo.GetAll().OrderBy(x => x.Id);
-		public IQueryable<FeedSubmissionEntry> Where(Expression<Func<FeedSubmissionEntry, bool>> predicate) => _feedRepo.GetAll().OrderBy(x => x.Id).Where(predicate);
+		public IEnumerable<FeedSubmissionEntry> GetAll() => _feedRepo.GetAll().OrderBy(x => x.Id);
+		public IEnumerable<FeedSubmissionEntry> Where(Func<FeedSubmissionEntry, bool> predicate) => _feedRepo.GetAll().OrderBy(x => x.Id).Where(predicate);
 		public FeedSubmissionEntry First() => _feedRepo.GetAll().OrderBy(x => x.Id).First();
 		public FeedSubmissionEntry FirstOrDefault() => _feedRepo.GetAll().OrderBy(x => x.Id).FirstOrDefault();
-		public FeedSubmissionEntry FirstOrDefault(Expression<Func<FeedSubmissionEntry, bool>> predicate) => _feedRepo.GetAll().OrderBy(x => x.Id).FirstOrDefault(predicate);
-		public FeedSubmissionEntry Last() => _feedRepo.GetAll().OrderByDescending(x => x.Id).First();
-		public FeedSubmissionEntry LastOrDefault() => _feedRepo.GetAll().OrderByDescending(x => x.Id).FirstOrDefault();
-		public FeedSubmissionEntry LastOrDefault(Expression<Func<FeedSubmissionEntry, bool>> predicate) => _feedRepo.GetAll().OrderByDescending(x => x.Id).FirstOrDefault(predicate);
-
+		public FeedSubmissionEntry FirstOrDefault(Func<FeedSubmissionEntry, bool> predicate) => _feedRepo.GetAll().OrderBy(x => x.Id).FirstOrDefault(predicate);
 		public FeedSubmissionEntry GetNextFromQueueOfFeedsToSubmit(string merchantId, AmazonRegion region, bool markEntryAsLocked = true)
 		{
 			var entry = FirstOrDefault(fse => fse.AmazonRegion == region && fse.MerchantId == merchantId

--- a/src/EasyMWS/EasyMWS/Services/IFeedSubmissionEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/IFeedSubmissionEntryService.cs
@@ -15,15 +15,11 @@ namespace MountainWarehouse.EasyMWS.Services
 	    void Delete(FeedSubmissionEntry entry);
 	    void DeleteRange(IEnumerable<FeedSubmissionEntry> entries);
 		void SaveChanges();
-	    IQueryable<FeedSubmissionEntry> GetAll();
-	    IQueryable<FeedSubmissionEntry> Where(Expression<Func<FeedSubmissionEntry, bool>> predicate);
+		IEnumerable<FeedSubmissionEntry> GetAll();
+		IEnumerable<FeedSubmissionEntry> Where(Func<FeedSubmissionEntry, bool> predicate);
 	    FeedSubmissionEntry First();
 	    FeedSubmissionEntry FirstOrDefault();
-	    FeedSubmissionEntry FirstOrDefault(Expression<Func<FeedSubmissionEntry, bool>> predicate);
-	    FeedSubmissionEntry Last();
-	    FeedSubmissionEntry LastOrDefault();
-	    FeedSubmissionEntry LastOrDefault(Expression<Func<FeedSubmissionEntry, bool>> predicate);
-
+	    FeedSubmissionEntry FirstOrDefault(Func<FeedSubmissionEntry, bool> predicate);
 	    FeedSubmissionEntry GetNextFromQueueOfFeedsToSubmit(string merchantId, AmazonRegion region, bool markEntryAsLocked = true);
 
 	    IEnumerable<string> GetIdsForSubmittedFeedsFromQueue(string merchantId, AmazonRegion region, bool markEntriesAsLocked = true);

--- a/src/EasyMWS/EasyMWS/Services/IReportRequestEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/IReportRequestEntryService.cs
@@ -18,15 +18,11 @@ namespace MountainWarehouse.EasyMWS.Services
 		void DeleteRange(IEnumerable<ReportRequestEntry> entries);
 		void SaveChanges();
 		Task SaveChangesAsync();
-		IQueryable<ReportRequestEntry> GetAll();
-		IQueryable<ReportRequestEntry> Where(Expression<Func<ReportRequestEntry, bool>> predicate);
+		IEnumerable<ReportRequestEntry> GetAll();
+		IEnumerable<ReportRequestEntry> Where(Func<ReportRequestEntry, bool> predicate);
 		ReportRequestEntry First();
 		ReportRequestEntry FirstOrDefault();
-		ReportRequestEntry FirstOrDefault(Expression<Func<ReportRequestEntry, bool>> predicate);
-		ReportRequestEntry Last();
-		ReportRequestEntry LastOrDefault();
-		ReportRequestEntry LastOrDefault(Expression<Func<ReportRequestEntry, bool>> predicate);
-
+		ReportRequestEntry FirstOrDefault(Func<ReportRequestEntry, bool> predicate);
 		ReportRequestEntry GetNextFromQueueOfReportsToRequest(string merchantId, AmazonRegion region, bool markEntryAsLocked = true);
 		ReportRequestEntry GetNextFromQueueOfReportsToDownload(string merchantId, AmazonRegion region, bool markEntryAsLocked = true);
 		IEnumerable<string> GetAllPendingReportFromQueue(string merchantId, AmazonRegion region, bool markEntriesAsLocked = true);

--- a/src/EasyMWS/EasyMWS/Services/ReportRequestEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/ReportRequestEntryService.cs
@@ -49,17 +49,13 @@ namespace MountainWarehouse.EasyMWS.Services
 
 		public void SaveChanges() => _reportRequestEntryRepository.SaveChanges();
 		public async Task SaveChangesAsync() => await _reportRequestEntryRepository.SaveChangesAsync();
-		public IQueryable<ReportRequestEntry> GetAll() => _reportRequestEntryRepository.GetAll().OrderBy(x => x.Id);
+		public IEnumerable<ReportRequestEntry> GetAll() => _reportRequestEntryRepository.GetAll().OrderBy(x => x.Id);
 
-		public IQueryable<ReportRequestEntry> Where(Expression<Func<ReportRequestEntry, bool>> predicate) => _reportRequestEntryRepository.GetAll().OrderBy(x => x.Id).Where(predicate);
+		public IEnumerable<ReportRequestEntry> Where(Func<ReportRequestEntry, bool> predicate) => _reportRequestEntryRepository.GetAll().OrderBy(x => x.Id).Where(predicate);
 
 		public ReportRequestEntry First() => _reportRequestEntryRepository.GetAll().OrderBy(x => x.Id).First();
 		public ReportRequestEntry FirstOrDefault() => _reportRequestEntryRepository.GetAll().OrderBy(x => x.Id).FirstOrDefault();
-		public ReportRequestEntry FirstOrDefault(Expression<Func<ReportRequestEntry, bool>> predicate) => _reportRequestEntryRepository.GetAll().OrderBy(x => x.Id).FirstOrDefault(predicate);
-
-		public ReportRequestEntry Last() => _reportRequestEntryRepository.GetAll().OrderByDescending(x => x.Id).First();
-		public ReportRequestEntry LastOrDefault() => _reportRequestEntryRepository.GetAll().OrderByDescending(x => x.Id).FirstOrDefault();
-		public ReportRequestEntry LastOrDefault(Expression<Func<ReportRequestEntry, bool>> predicate) => _reportRequestEntryRepository.GetAll().OrderByDescending(x => x.Id).FirstOrDefault(predicate);
+		public ReportRequestEntry FirstOrDefault(Func<ReportRequestEntry, bool> predicate) => _reportRequestEntryRepository.GetAll().OrderBy(x => x.Id).FirstOrDefault(predicate);
 
 		public ReportRequestEntry GetNextFromQueueOfReportsToRequest(string merchantId, AmazonRegion region, bool markEntryAsLocked = true)
 		{


### PR DESCRIPTION
These were caused for some reason because of using Expression<Func<object, bool>> to pass filters to custom where / any or similar internal service methods.
The reason seems to be a pile up of evaluation expressions in memory in part because of Expression<Func<>> evaluating to IQueryable. After Expression<Func<>> was replaced with Func<> it evaluates to IEnumerable, so evaluation expressions don't keep piling up in memory. The downside is queries now get all db entries in memory, but this should not be a problem because the cleanup mechanism prevents entry tables from getting too big (entries older than 1/2 days are deleted). To put things in context, the memory leaks in question could lead to OutOfMemory exceptions popping up on a machine.