### PR TITLE
Feature/add support for done no data status callback

### DIFF
--- a/src/EasyMWS/EasyMWS/Data/FeedSubmissionEntry.cs
+++ b/src/EasyMWS/EasyMWS/Data/FeedSubmissionEntry.cs
@@ -27,7 +27,8 @@ namespace MountainWarehouse.EasyMWS.Data
 	    public int ReportDownloadRetryCount { get; set; }
 	    public int InvokeCallbackRetryCount { get; set; }
 		public DateTime LastSubmitted { get; set; }
-	    public DateTime DateCreated { get; set; }
+        public string LastAmazonFeedProcessingStatus { get; set; }
+        public DateTime DateCreated { get; set; }
 
 		#region Serialized callback data necessary to invoke a method with it's argument values.
 		public string TypeName { get; set; }
@@ -70,7 +71,8 @@ namespace MountainWarehouse.EasyMWS.Data
 		    Data = callback?.Data;
 		    DataTypeName = callback?.DataTypeName;
 		    FeedSubmissionData = feedSubmissionData;
-	    }
+            LastAmazonFeedProcessingStatus = null;
+        }
 	}
 
 	internal static class FeedSubmissionCallbackExtensions

--- a/src/EasyMWS/EasyMWS/Data/ReportRequestEntry.cs
+++ b/src/EasyMWS/EasyMWS/Data/ReportRequestEntry.cs
@@ -26,6 +26,7 @@ namespace MountainWarehouse.EasyMWS.Data
 		public int InvokeCallbackRetryCount { get; set; }
 		public int ReportProcessRetryCount { get; set; }
 		public DateTime LastAmazonRequestDate { get; set; }
+        public string LastAmazonReportProcessingStatus { get; set; }
 		public DateTime DateCreated { get; set; }
 
 		#region Serialized callback data necessary to invoke a method with it's argument values.
@@ -76,7 +77,9 @@ namespace MountainWarehouse.EasyMWS.Data
 			Data = callback?.Data;
 			DataTypeName = callback?.DataTypeName;
 			ReportRequestData = reportRequestData;
-		}
+            LastAmazonReportProcessingStatus = null;
+
+        }
 	}
 
 	internal static class ReportRequestCallbackExtensions

--- a/src/EasyMWS/EasyMWS/Migrations/20181110165803_AddLastProcessingStatusToEntryTables.Designer.cs
+++ b/src/EasyMWS/EasyMWS/Migrations/20181110165803_AddLastProcessingStatusToEntryTables.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MountainWarehouse.EasyMWS.Data;
 
 namespace MountainWarehouse.EasyMWS.Migrations
 {
     [DbContext(typeof(EasyMwsContext))]
-    partial class EasyMwsContextModelSnapshot : ModelSnapshot
+    [Migration("20181110165803_AddLastProcessingStatusToEntryTables")]
+    partial class AddLastProcessingStatusToEntryTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/EasyMWS/EasyMWS/Migrations/20181110165803_AddLastProcessingStatusToEntryTables.cs
+++ b/src/EasyMWS/EasyMWS/Migrations/20181110165803_AddLastProcessingStatusToEntryTables.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace MountainWarehouse.EasyMWS.Migrations
+{
+    public partial class AddLastProcessingStatusToEntryTables : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "LastAmazonReportProcessingStatus",
+                table: "ReportRequestEntries",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "LastAmazonFeedProcessingStatus",
+                table: "FeedSubmissionEntries",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LastAmazonReportProcessingStatus",
+                table: "ReportRequestEntries");
+
+            migrationBuilder.DropColumn(
+                name: "LastAmazonFeedProcessingStatus",
+                table: "FeedSubmissionEntries");
+        }
+    }
+}

--- a/src/EasyMWS/EasyMWS/Model/AmazonFeedProcessingStatus.cs
+++ b/src/EasyMWS/EasyMWS/Model/AmazonFeedProcessingStatus.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MountainWarehouse.EasyMWS.Model
+{
+    internal class AmazonFeedProcessingStatus
+    {
+        public const string Done = "_DONE_";
+        public const string Cancelled = "_CANCELLED_";
+        public const string AwaitingAsyncReply = "_AWAITING_ASYNCHRONOUS_REPLY_";
+        public const string InProgress = "_IN_PROGRESS_";
+        public const string InSafetyNet = "_IN_SAFETY_NET_";
+        public const string Submitted = "_SUBMITTED_";
+        public const string Unconfirmed = "_UNCONFIRMED_";
+    }
+}

--- a/src/EasyMWS/EasyMWS/Model/AmazonReportProcessingStatus.cs
+++ b/src/EasyMWS/EasyMWS/Model/AmazonReportProcessingStatus.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MountainWarehouse.EasyMWS.Model
+{
+    internal class AmazonReportProcessingStatus
+    {
+        public const string Done = "_DONE_";
+        public const string DoneNoData = "_DONE_NO_DATA_";
+        public const string Submitted = "_SUBMITTED_";
+        public const string InProgress = "_IN_PROGRESS_";
+        public const string Cancelled = "_CANCELLED_";
+    }
+}

--- a/src/EasyMWS/EasyMWS/Model/EasyMwsOptions.cs
+++ b/src/EasyMWS/EasyMWS/Model/EasyMwsOptions.cs
@@ -110,35 +110,36 @@ namespace MountainWarehouse.EasyMWS.Model
 
         public bool InvokeCallbackForReportStatusDoneNoData { get; set; }
 
-		/// <summary>
-		/// The set of default settings that will be used if no custom settings are specified.<para/>
-		/// InvokeCallbackMaxRetryCount = 5,<para/>
-		/// InvokeCallbackRetryPeriodType = RetryPeriodType.ArithmeticProgression,<para/>
-		/// InvokeCallbackRetryInterval = TimeSpan.FromMinutes(30),<para/>
-		/// <para/>
-		/// ReportRequestMaxRetryCount = 4,<para/>
-		/// ReportRequestRetryType = RetryPeriodType.GeometricProgression,<para/>
-		/// ReportRequestRetryInitialDelay = TimeSpan.FromMinutes(30),<para/>
-		/// ReportRequestRetryInterval = TimeSpan.FromHours(1),<para/>
-		/// <para/>
-		/// ReportDownloadMaxRetryCount = 4,<para/>
-		/// ReportDownloadRetryType = RetryPeriodType.GeometricProgression,<para/>
-		/// ReportDownloadRetryInitialDelay = TimeSpan.FromMinutes(30),<para/>
-		/// ReportDownloadRetryInterval = TimeSpan.FromHours(1),<para/>
-		/// <para/>
-		/// ReportProcessingMaxRetryCount = 3<para/>
-		/// FeedProcessingMaxRetryCount = 3<para/>
-		/// <para/>
-		/// FeedSubmissionMaxRetryCount = 3,<para/>
-		/// FeedSubmissionRetryType = RetryPeriodType.GeometricProgression,<para/>
-		/// FeedSubmissionRetryInitialDelay = TimeSpan.FromMinutes(30),<para/>
-		/// FeedSubmissionRetryInterval = TimeSpan.FromHours(1),<para/>
-		/// <para/>
-		/// ReportDownloadRequestEntryExpirationPeriod = TimeSpan.FromDays(1),<para/>
-		/// FeedSubmissionRequestEntryExpirationPeriod = TimeSpan.FromDays(2)<para/>
-		/// <para/>
-		/// </summary>
-		public static EasyMwsOptions Defaults()
+        /// <summary>
+        /// The set of default settings that will be used if no custom settings are specified.<para/>
+        /// InvokeCallbackMaxRetryCount = 5,<para/>
+        /// InvokeCallbackRetryPeriodType = RetryPeriodType.ArithmeticProgression,<para/>
+        /// InvokeCallbackRetryInterval = TimeSpan.FromMinutes(30),<para/>
+        /// <para/>
+        /// ReportRequestMaxRetryCount = 4,<para/>
+        /// ReportRequestRetryType = RetryPeriodType.GeometricProgression,<para/>
+        /// ReportRequestRetryInitialDelay = TimeSpan.FromMinutes(30),<para/>
+        /// ReportRequestRetryInterval = TimeSpan.FromHours(1),<para/>
+        /// <para/>
+        /// ReportDownloadMaxRetryCount = 4,<para/>
+        /// ReportDownloadRetryType = RetryPeriodType.GeometricProgression,<para/>
+        /// ReportDownloadRetryInitialDelay = TimeSpan.FromMinutes(30),<para/>
+        /// ReportDownloadRetryInterval = TimeSpan.FromHours(1),<para/>
+        /// <para/>
+        /// ReportProcessingMaxRetryCount = 3<para/>
+        /// FeedProcessingMaxRetryCount = 3<para/>
+        /// <para/>
+        /// FeedSubmissionMaxRetryCount = 3,<para/>
+        /// FeedSubmissionRetryType = RetryPeriodType.GeometricProgression,<para/>
+        /// FeedSubmissionRetryInitialDelay = TimeSpan.FromMinutes(30),<para/>
+        /// FeedSubmissionRetryInterval = TimeSpan.FromHours(1),<para/>
+        /// <para/>
+        /// ReportDownloadRequestEntryExpirationPeriod = TimeSpan.FromDays(1),<para/>
+        /// FeedSubmissionRequestEntryExpirationPeriod = TimeSpan.FromDays(2),<para/>
+        /// <para/>
+        /// InvokeCallbackForReportStatusDoneNoData = false<para/>
+        /// </summary>
+        public static EasyMwsOptions Defaults()
 		{
 			const int worstCaseScenarioRetryInitialDelay = 10;
 			const int worstCaseScenarioRetryInterval = 1;

--- a/src/EasyMWS/EasyMWS/Model/EasyMwsOptions.cs
+++ b/src/EasyMWS/EasyMWS/Model/EasyMwsOptions.cs
@@ -108,6 +108,7 @@ namespace MountainWarehouse.EasyMWS.Model
 	    /// </summary>
 	    public TimeSpan FeedSubmissionRequestEntryExpirationPeriod { get; set; }
 
+        public bool InvokeCallbackForReportStatusDoneNoData { get; set; }
 
 		/// <summary>
 		/// The set of default settings that will be used if no custom settings are specified.<para/>
@@ -171,8 +172,10 @@ namespace MountainWarehouse.EasyMWS.Model
 			    FeedSubmissionRetryInterval = TimeSpan.FromHours(worstCaseScenarioRetryInterval),
 
 			    ReportDownloadRequestEntryExpirationPeriod = TimeSpan.FromDays(1),
-				FeedSubmissionRequestEntryExpirationPeriod = TimeSpan.FromDays(2)
-			};
+				FeedSubmissionRequestEntryExpirationPeriod = TimeSpan.FromDays(2),
+
+                InvokeCallbackForReportStatusDoneNoData = false
+            };
 		}
 	}
 

--- a/src/EasyMWS/EasyMWS/Processors/RequestReportProcessor.cs
+++ b/src/EasyMWS/EasyMWS/Processors/RequestReportProcessor.cs
@@ -186,29 +186,31 @@ namespace MountainWarehouse.EasyMWS.Processors
 			foreach (var reportGenerationInfo in reportGenerationStatuses)
 			{
 				var reportRequestEntry = reportRequestService.FirstOrDefault(rrc => rrc.RequestReportId == reportGenerationInfo.ReportRequestId && rrc.GeneratedReportId == null);
-				if (reportRequestEntry == null) continue;
+                if (reportRequestEntry == null) continue;
 				reportRequestEntry.IsLocked = false;
 
-				var genericProcessingInfo = $"ProcessingStatus returned by Amazon for {reportRequestEntry.RegionAndTypeComputed} is '{reportGenerationInfo.ReportProcessingStatus}'.";
+                reportRequestEntry.LastAmazonReportProcessingStatus = reportGenerationInfo.ReportProcessingStatus;
 
-				if (reportGenerationInfo.ReportProcessingStatus == "_DONE_")
+                var genericProcessingInfo = $"ProcessingStatus returned by Amazon for {reportRequestEntry.RegionAndTypeComputed} is '{reportGenerationInfo.ReportProcessingStatus}'.";
+
+				if (reportGenerationInfo.ReportProcessingStatus == AmazonReportProcessingStatus.Done)
 				{
 					reportRequestEntry.GeneratedReportId = reportGenerationInfo.GeneratedReportId;
 					reportRequestEntry.ReportProcessRetryCount = 0;
 					reportRequestService.Update(reportRequestEntry);
 					_logger.Info($"{genericProcessingInfo}. The report is now ready for download.");
 				}
-				else if (reportGenerationInfo.ReportProcessingStatus == "_DONE_NO_DATA_")
+				else if (reportGenerationInfo.ReportProcessingStatus == AmazonReportProcessingStatus.DoneNoData)
 				{
 					reportRequestService.Delete(reportRequestEntry);
 					_logger.Warn($"{genericProcessingInfo}. The Report request entry will now be removed from queue.");
 				}
-				else if (reportGenerationInfo.ReportProcessingStatus == "_SUBMITTED_" 
-					  || reportGenerationInfo.ReportProcessingStatus == "_IN_PROGRESS_")
+				else if (reportGenerationInfo.ReportProcessingStatus == AmazonReportProcessingStatus.Submitted 
+					  || reportGenerationInfo.ReportProcessingStatus == AmazonReportProcessingStatus.InProgress)
 				{
 					_logger.Info($"{genericProcessingInfo}. The report processing status will be checked again at the next poll request.");
 				}
-				else if (reportGenerationInfo.ReportProcessingStatus == "_CANCELLED_")
+				else if (reportGenerationInfo.ReportProcessingStatus == AmazonReportProcessingStatus.Cancelled)
 				{
 					reportRequestEntry.RequestReportId = null;
 					reportRequestEntry.GeneratedReportId = null;

--- a/src/EasyMWS/EasyMWS/Services/ReportRequestEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/ReportRequestEntryService.cs
@@ -118,7 +118,7 @@ namespace MountainWarehouse.EasyMWS.Services
 		public IEnumerable<ReportRequestEntry> GetAllFromQueueOfReportsReadyForCallback(string merchantId, AmazonRegion region, bool markEntriesAsLocked = true)
 		{
 			var entries = Where(rre => rre.AmazonRegion == region && rre.MerchantId == merchantId
-							  && rre.Details != null
+							  && (rre.Details != null || rre.LastAmazonReportProcessingStatus == AmazonReportProcessingStatus.DoneNoData)
 							  && RetryIntervalHelper.IsRetryPeriodAwaited(rre.LastAmazonRequestDate, rre.InvokeCallbackRetryCount,
 							   _options.InvokeCallbackRetryInterval, _options.InvokeCallbackRetryInterval,
 							   _options.InvokeCallbackRetryPeriodType) && rre.IsLocked == false).ToList();

--- a/src/EasyMWS/EasyMWS/Services/ReportRequestEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/ReportRequestEntryService.cs
@@ -80,8 +80,8 @@ namespace MountainWarehouse.EasyMWS.Services
 		public ReportRequestEntry GetNextFromQueueOfReportsToDownload(string merchantId, AmazonRegion region, bool markEntryAsLocked = true)
 		{
 			var entry = FirstOrDefault(rre => rre.AmazonRegion == region && rre.MerchantId == merchantId
-							 && rre.RequestReportId != null && rre.GeneratedReportId != null && rre.Details == null
-							 && RetryIntervalHelper.IsRetryPeriodAwaited(rre.LastAmazonRequestDate, rre.ReportDownloadRetryCount,
+							 && rre.RequestReportId != null && rre.GeneratedReportId != null && rre.Details == null && rre.LastAmazonReportProcessingStatus != AmazonReportProcessingStatus.DoneNoData
+                             && RetryIntervalHelper.IsRetryPeriodAwaited(rre.LastAmazonRequestDate, rre.ReportDownloadRetryCount,
 									   _options.ReportDownloadRetryInitialDelay, _options.ReportDownloadRetryInterval,
 									   _options.ReportDownloadRetryType)
 									   && rre.IsLocked == false);


### PR DESCRIPTION
GIVEN the QueueReport functionality is used to queue a report download from amazon 

WHEN the InvokeCallbackForReportStatusDoneNoData EasyMwsOption is set to True 
AND the report receives the _DONE_NO_DATA_ processing status from amazon
THEN the callback target provided at QueueReport will be invoked
AND the Stream argument will be null - this should allow this scenario to be handled properly.

WHEN the InvokeCallbackForReportStatusDoneNoData EasyMwsOption is set to False
AND the report receives the _DONE_NO_DATA_ processing status from amazon
THEN the callback target provided at QueueReport will NOT be invoked