### PR TITLE
Feature/issue 82 execute callbacks on origin machine

### DIFF
--- a/src/EasyMWS/EasyMWS.Tests/EndToEnd/ReportDownloadingTests.cs
+++ b/src/EasyMWS/EasyMWS.Tests/EndToEnd/ReportDownloadingTests.cs
@@ -171,12 +171,12 @@ namespace EasyMWS.Tests.EndToEnd
 		    var validReportType = $"{_testEntriesIdentifier}_VALID_REPORT_TYPE_";
 		    Setup_RequestReport_Returns_ReportRequestNotGeneratedYet(validReportType);
 		    var reportRequestContainer = GenerateReportContainer(validReportType);
-			_options.ReportRequestRetryInitialDelay = TimeSpan.Zero;
-			_options.ReportRequestRetryInterval = TimeSpan.Zero;
+			_options.ReportRequestOptions.ReportRequestRetryInitialDelay = TimeSpan.Zero;
+			_options.ReportRequestOptions.ReportRequestRetryInterval = TimeSpan.Zero;
 
 			_easyMwsClient.QueueReport(reportRequestContainer, ReportDownloadCallback, "callbackData");
 
-		    var retryCount = _options.ReportRequestMaxRetryCount;
+		    var retryCount = _options.ReportRequestOptions.ReportRequestMaxRetryCount;
 
 		    for (int i = 0; i <= retryCount; i++)
 		    {

--- a/src/EasyMWS/EasyMWS.Tests/Helpers/EntryInvocationRestrictionHelperTests.cs
+++ b/src/EasyMWS/EasyMWS.Tests/Helpers/EntryInvocationRestrictionHelperTests.cs
@@ -1,0 +1,109 @@
+﻿using MountainWarehouse.EasyMWS.Data;
+using MountainWarehouse.EasyMWS.Helpers;
+using MountainWarehouse.EasyMWS.Model;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace EasyMWS.Tests.Helpers
+{
+    public class EntryInvocationRestrictionHelperTests
+    {
+        private List<ReportRequestEntry> _reportRequestEntries;
+        private const string _originatingInstance = "instanceId1";
+        private string _originatingInstanceHash;
+        private EasyMwsOptions _options;
+
+        [SetUp]
+        public void Setup()
+        {
+            _options = new EasyMwsOptions(useDefaultValues: true);
+            _options.CallbackInvocationOptions.RestrictInvocationToOriginatingInstance.CustomInstanceId = _originatingInstance;
+            _originatingInstanceHash = _options.CallbackInvocationOptions.RestrictInvocationToOriginatingInstance.HashedInstanceId;
+
+            _reportRequestEntries = new List<ReportRequestEntry>
+            {
+                new ReportRequestEntry { Id = 1, InstanceId = _originatingInstanceHash, InvokeCallbackRetryCount = 0 },
+                new ReportRequestEntry { Id = 2, InstanceId = "non-originating-instance1-hash", InvokeCallbackRetryCount = 3 },
+                new ReportRequestEntry { Id = 3, InstanceId = "non-originating-instance2-hash", InvokeCallbackRetryCount = 0 },
+                new ReportRequestEntry { Id = 4, InstanceId = _originatingInstanceHash, InvokeCallbackRetryCount = 0 },
+            };
+        }
+
+        [Test]
+        public void EntryInvocationRestrictionHelper_WithNonDefinedinvocationRestrictionOptions_ReturnsSameEntries()
+        {
+            _options.CallbackInvocationOptions.RestrictInvocationToOriginatingInstance = null;
+
+            var filteredEntries = EntryInvocationRestrictionHelper<ReportRequestEntry>.RestrictInvocationToOriginatingClientsIfEnabled(_reportRequestEntries, _options);
+
+            CollectionAssert.AreEquivalent(_reportRequestEntries, filteredEntries);
+        }
+
+        [Test]
+        public void EntryInvocationRestrictionHelper_WithForceInvocationByOriginatingInstanceOptionSetToFalse_ReturnsSameEntries()
+        {
+            _options.CallbackInvocationOptions.RestrictInvocationToOriginatingInstance.ForceInvocationByOriginatingInstance = false;
+
+            var filteredEntries = EntryInvocationRestrictionHelper<ReportRequestEntry>.RestrictInvocationToOriginatingClientsIfEnabled(_reportRequestEntries, _options);
+
+            CollectionAssert.AreEquivalent(_reportRequestEntries, filteredEntries);
+        }
+
+        [TestCase(false, 2)]
+        [TestCase(true, 3)]
+        public void EntryInvocationRestrictionHelper_WithForceInvocationByOriginatingInstanceOptionSetToTrue_AndCustomInstanceId_ReturnsCorrectEntries(bool allowInvocationByAnyInstance, int expectedNumberOfEntries)
+        {
+            _options.CallbackInvocationOptions.RestrictInvocationToOriginatingInstance.ForceInvocationByOriginatingInstance = true;
+            _options.CallbackInvocationOptions.RestrictInvocationToOriginatingInstance.AllowInvocationByAnyInstanceIfInvocationFailedLimitReached = allowInvocationByAnyInstance;
+            var allowedFailures = 2;
+            _options.CallbackInvocationOptions.RestrictInvocationToOriginatingInstance.InvocationFailuresLimit = allowedFailures;
+
+            var filteredEntries = EntryInvocationRestrictionHelper<ReportRequestEntry>.RestrictInvocationToOriginatingClientsIfEnabled(_reportRequestEntries, _options);
+
+            CollectionAssert.AreNotEquivalent(_reportRequestEntries, filteredEntries);
+            Assert.IsTrue(filteredEntries.Count == expectedNumberOfEntries);
+
+            if (!allowInvocationByAnyInstance) Assert.IsTrue(filteredEntries.All(e => e.InstanceId == _originatingInstanceHash));
+            else Assert.IsTrue(
+                filteredEntries.Count(e => e.InstanceId == _originatingInstanceHash) == 2 && 
+                filteredEntries.Count(e => e.InstanceId != _originatingInstanceHash && e.InvokeCallbackRetryCount > allowedFailures) == 1);
+
+        }
+
+        [TestCase(false, 2)]
+        [TestCase(true, 3)]
+        public void EntryInvocationRestrictionHelper_WithForceInvocationByOriginatingInstanceOptionSetToTrue_AndDefaultInstanceId_ReturnsCorrectEntries(bool allowInvocationByAnyInstance, int expectedNumberOfEntries)
+        {
+            _options = new EasyMwsOptions(useDefaultValues: true);
+            _options.CallbackInvocationOptions.RestrictInvocationToOriginatingInstance.CustomInstanceId = null;
+            _originatingInstanceHash = _options.CallbackInvocationOptions.RestrictInvocationToOriginatingInstance.HashedInstanceId;
+
+            _reportRequestEntries = new List<ReportRequestEntry>
+            {
+                new ReportRequestEntry { Id = 1, InstanceId = _originatingInstanceHash, InvokeCallbackRetryCount = 0 },
+                new ReportRequestEntry { Id = 2, InstanceId = "non-originating-instance1-hash", InvokeCallbackRetryCount = 3 },
+                new ReportRequestEntry { Id = 3, InstanceId = "non-originating-instance2-hash", InvokeCallbackRetryCount = 0 },
+                new ReportRequestEntry { Id = 4, InstanceId = _originatingInstanceHash, InvokeCallbackRetryCount = 0 },
+            };
+
+            _options.CallbackInvocationOptions.RestrictInvocationToOriginatingInstance.ForceInvocationByOriginatingInstance = true;
+            _options.CallbackInvocationOptions.RestrictInvocationToOriginatingInstance.AllowInvocationByAnyInstanceIfInvocationFailedLimitReached = allowInvocationByAnyInstance;
+            var allowedFailures = 2;
+            _options.CallbackInvocationOptions.RestrictInvocationToOriginatingInstance.InvocationFailuresLimit = allowedFailures;
+
+            var filteredEntries = EntryInvocationRestrictionHelper<ReportRequestEntry>.RestrictInvocationToOriginatingClientsIfEnabled(_reportRequestEntries, _options);
+
+            CollectionAssert.AreNotEquivalent(_reportRequestEntries, filteredEntries);
+            Assert.IsTrue(filteredEntries.Count == expectedNumberOfEntries);
+
+            if (!allowInvocationByAnyInstance) Assert.IsTrue(filteredEntries.All(e => e.InstanceId == _originatingInstanceHash));
+            else Assert.IsTrue(
+                filteredEntries.Count(e => e.InstanceId == _originatingInstanceHash) == 2 &&
+                filteredEntries.Count(e => e.InstanceId != _originatingInstanceHash && e.InvokeCallbackRetryCount > allowedFailures) == 1);
+
+        }
+    }
+}

--- a/src/EasyMWS/EasyMWS.Tests/Processors/FeedSubmissionProcessorTests.cs
+++ b/src/EasyMWS/EasyMWS.Tests/Processors/FeedSubmissionProcessorTests.cs
@@ -301,9 +301,9 @@ namespace EasyMWS.Tests.Processors
 			var data = JsonConvert.SerializeObject(propertiesContainer);
 
 			var retryCount =
-				retryCountType == -1 ? _easyMwsOptions.FeedSubmissionMaxRetryCount - 1 :
-				retryCountType == 0 ? _easyMwsOptions.FeedSubmissionMaxRetryCount :
-				retryCountType == 1 ? _easyMwsOptions.FeedSubmissionMaxRetryCount + 1 : 0;
+				retryCountType == -1 ? _easyMwsOptions.FeedSubmissionOptions.FeedSubmissionMaxRetryCount - 1 :
+				retryCountType == 0 ? _easyMwsOptions.FeedSubmissionOptions.FeedSubmissionMaxRetryCount :
+				retryCountType == 1 ? _easyMwsOptions.FeedSubmissionOptions.FeedSubmissionMaxRetryCount + 1 : 0;
 
 			var firstEntryToDelete = new FeedSubmissionEntry
 			{
@@ -337,9 +337,9 @@ namespace EasyMWS.Tests.Processors
 			var data = JsonConvert.SerializeObject(propertiesContainer);
 
 			var retryCount =
-				retryCountType == -1 ? _easyMwsOptions.FeedProcessingMaxRetryCount - 1 :
-				retryCountType == 0 ? _easyMwsOptions.FeedProcessingMaxRetryCount :
-				retryCountType == 1 ? _easyMwsOptions.FeedProcessingMaxRetryCount + 1 : 0;
+				retryCountType == -1 ? _easyMwsOptions.FeedSubmissionOptions.FeedProcessingMaxRetryCount - 1 :
+				retryCountType == 0 ? _easyMwsOptions.FeedSubmissionOptions.FeedProcessingMaxRetryCount :
+				retryCountType == 1 ? _easyMwsOptions.FeedSubmissionOptions.FeedProcessingMaxRetryCount + 1 : 0;
 
 			var firstEntryToDelete = new FeedSubmissionEntry
 			{
@@ -377,9 +377,9 @@ namespace EasyMWS.Tests.Processors
 			var data = JsonConvert.SerializeObject(propertiesContainer);
 
 			var retryCount =
-				retryCountType == -1 ? _easyMwsOptions.ReportDownloadMaxRetryCount - 1 :
-				retryCountType == 0 ? _easyMwsOptions.ReportDownloadMaxRetryCount :
-				retryCountType == 1 ? _easyMwsOptions.ReportDownloadMaxRetryCount + 1 : 0;
+				retryCountType == -1 ? _easyMwsOptions.ReportRequestOptions.ReportDownloadMaxRetryCount - 1 :
+				retryCountType == 0 ? _easyMwsOptions.ReportRequestOptions.ReportDownloadMaxRetryCount :
+				retryCountType == 1 ? _easyMwsOptions.ReportRequestOptions.ReportDownloadMaxRetryCount + 1 : 0;
 
 			var firstEntryToDelete = new FeedSubmissionEntry
 			{
@@ -417,9 +417,9 @@ namespace EasyMWS.Tests.Processors
 			var data = JsonConvert.SerializeObject(propertiesContainer);
 
 			var retryCount =
-				retryCountType == -1 ? _easyMwsOptions.InvokeCallbackMaxRetryCount - 1 :
-				retryCountType == 0 ? _easyMwsOptions.InvokeCallbackMaxRetryCount :
-				retryCountType == 1 ? _easyMwsOptions.InvokeCallbackMaxRetryCount + 1 : 0;
+				retryCountType == -1 ? _easyMwsOptions.CallbackInvocationOptions.InvokeCallbackMaxRetryCount - 1 :
+				retryCountType == 0 ? _easyMwsOptions.CallbackInvocationOptions.InvokeCallbackMaxRetryCount :
+				retryCountType == 1 ? _easyMwsOptions.CallbackInvocationOptions.InvokeCallbackMaxRetryCount + 1 : 0;
 
 			var firstEntryToDelete = new FeedSubmissionEntry
 			{

--- a/src/EasyMWS/EasyMWS.Tests/Processors/RequestReportProcessorTests.cs
+++ b/src/EasyMWS/EasyMWS.Tests/Processors/RequestReportProcessorTests.cs
@@ -412,7 +412,7 @@ namespace EasyMWS.Tests.Processors
         [Test]
         public void QueueReportsAccordingToProcessingStatus_InvokeCallbackForReportStatusDoneNoDataTrue_DoesNotDeleteEntry()
         {
-            _easyMwsOptions.InvokeCallbackForReportStatusDoneNoData = true;
+            _easyMwsOptions.CallbackInvocationOptions.InvokeCallbackForReportStatusDoneNoData = true;
             var propertiesContainer = new ReportRequestPropertiesContainer("testReportType", ContentUpdateFrequency.Unknown);
             var serializedReportRequestData = JsonConvert.SerializeObject(propertiesContainer);
             var data = new List<ReportRequestEntry>
@@ -447,7 +447,7 @@ namespace EasyMWS.Tests.Processors
         [Test]
         public void QueueReportsAccordingToProcessingStatus_InvokeCallbackForReportStatusDoneNoDataFalse_DeletesEntry()
         {
-            _easyMwsOptions.InvokeCallbackForReportStatusDoneNoData = false;
+            _easyMwsOptions.CallbackInvocationOptions.InvokeCallbackForReportStatusDoneNoData = false;
             var propertiesContainer = new ReportRequestPropertiesContainer("testReportType", ContentUpdateFrequency.Unknown);
             var serializedReportRequestData = JsonConvert.SerializeObject(propertiesContainer);
             var data = new List<ReportRequestEntry>
@@ -825,9 +825,9 @@ namespace EasyMWS.Tests.Processors
 			var data = JsonConvert.SerializeObject(propertiesContainer);
 
 			var retryCount =
-				retryCountType == -1 ? _easyMwsOptions.ReportRequestMaxRetryCount - 1 :
-				retryCountType == 0 ? _easyMwsOptions.ReportRequestMaxRetryCount :
-				retryCountType == 1 ? _easyMwsOptions.ReportRequestMaxRetryCount + 1 : 0;
+				retryCountType == -1 ? _easyMwsOptions.ReportRequestOptions.ReportRequestMaxRetryCount - 1 :
+				retryCountType == 0 ? _easyMwsOptions.ReportRequestOptions.ReportRequestMaxRetryCount :
+				retryCountType == 1 ? _easyMwsOptions.ReportRequestOptions.ReportRequestMaxRetryCount + 1 : 0;
 
 			var firstEntryToDelete = new ReportRequestEntry
 			{
@@ -866,9 +866,9 @@ namespace EasyMWS.Tests.Processors
 			var data = JsonConvert.SerializeObject(propertiesContainer);
 
 			var retryCount =
-				retryCountType == -1 ? _easyMwsOptions.ReportDownloadMaxRetryCount - 1 :
-				retryCountType == 0 ? _easyMwsOptions.ReportDownloadMaxRetryCount :
-				retryCountType == 1 ? _easyMwsOptions.ReportDownloadMaxRetryCount + 1 : 0;
+				retryCountType == -1 ? _easyMwsOptions.ReportRequestOptions.ReportDownloadMaxRetryCount - 1 :
+				retryCountType == 0 ? _easyMwsOptions.ReportRequestOptions.ReportDownloadMaxRetryCount :
+				retryCountType == 1 ? _easyMwsOptions.ReportRequestOptions.ReportDownloadMaxRetryCount + 1 : 0;
 
 			var firstEntryToDelete = new ReportRequestEntry
 			{
@@ -914,9 +914,9 @@ namespace EasyMWS.Tests.Processors
 			var data = JsonConvert.SerializeObject(propertiesContainer);
 
 			var retryCount =
-				retryCountType == -1 ? _easyMwsOptions.ReportProcessingMaxRetryCount - 1 :
-				retryCountType == 0 ? _easyMwsOptions.ReportProcessingMaxRetryCount :
-				retryCountType == 1 ? _easyMwsOptions.ReportProcessingMaxRetryCount + 1 : 0;
+				retryCountType == -1 ? _easyMwsOptions.ReportRequestOptions.ReportProcessingMaxRetryCount - 1 :
+				retryCountType == 0 ? _easyMwsOptions.ReportRequestOptions.ReportProcessingMaxRetryCount :
+				retryCountType == 1 ? _easyMwsOptions.ReportRequestOptions.ReportProcessingMaxRetryCount + 1 : 0;
 
 			var firstEntryToDelete = new ReportRequestEntry
 			{
@@ -962,9 +962,9 @@ namespace EasyMWS.Tests.Processors
 			var data = JsonConvert.SerializeObject(propertiesContainer);
 
 			var retryCount =
-				retryCountType == -1 ? _easyMwsOptions.InvokeCallbackMaxRetryCount - 1 :
-				retryCountType == 0 ? _easyMwsOptions.InvokeCallbackMaxRetryCount :
-				retryCountType == 1 ? _easyMwsOptions.InvokeCallbackMaxRetryCount + 1 : 0;
+				retryCountType == -1 ? _easyMwsOptions.CallbackInvocationOptions.InvokeCallbackMaxRetryCount - 1 :
+				retryCountType == 0 ? _easyMwsOptions.CallbackInvocationOptions.InvokeCallbackMaxRetryCount :
+				retryCountType == 1 ? _easyMwsOptions.CallbackInvocationOptions.InvokeCallbackMaxRetryCount + 1 : 0;
 
 			var firstEntryToDelete = new ReportRequestEntry
 			{

--- a/src/EasyMWS/EasyMWS.Tests/Services/ReportRequestEntryServiceTests.cs
+++ b/src/EasyMWS/EasyMWS.Tests/Services/ReportRequestEntryServiceTests.cs
@@ -183,8 +183,8 @@ namespace EasyMWS.Tests.Services
 		{
 			var customOptions = new EasyMwsOptions();
 			var reportRequestWithRequestRetryPeriodIncomplete = new ReportRequestEntry { AmazonRegion = AmazonRegion.Europe, MerchantId = _merchantId, Id = 2, RequestReportId = null, ReportRequestRetryCount = 1, LastAmazonRequestDate = DateTime.UtcNow.AddHours(-1) };
-			customOptions.ReportRequestRetryInitialDelay = TimeSpan.FromHours(2);
-			customOptions.ReportRequestRetryInterval = TimeSpan.FromHours(2);
+			customOptions.ReportRequestOptions.ReportRequestRetryInitialDelay = TimeSpan.FromHours(2);
+			customOptions.ReportRequestOptions.ReportRequestRetryInterval = TimeSpan.FromHours(2);
 			var reportRequestWithNoRequestRetryCount1 = new ReportRequestEntry { AmazonRegion = AmazonRegion.Europe, MerchantId = _merchantId, Id = 3, RequestReportId = null, ReportRequestRetryCount = 0, LastAmazonRequestDate = DateTime.MinValue };
 			var reportRequestWithNoRequestRetryCount2 = new ReportRequestEntry { AmazonRegion = AmazonRegion.Europe, MerchantId = _merchantId, Id = 4, RequestReportId = null, ReportRequestRetryCount = 0, LastAmazonRequestDate = DateTime.MinValue };
 
@@ -205,8 +205,8 @@ namespace EasyMWS.Tests.Services
 		{
 			var customOptions = new EasyMwsOptions();
 			var reportRequestWithRequestRetryPeriodIncomplete = new ReportRequestEntry { AmazonRegion = AmazonRegion.Europe, MerchantId = _merchantId, Id = 2, RequestReportId = null, ReportRequestRetryCount = 1, LastAmazonRequestDate = DateTime.UtcNow.AddMinutes(-30) };
-			customOptions.ReportRequestRetryInitialDelay = TimeSpan.FromHours(1);
-			customOptions.ReportRequestRetryInterval = TimeSpan.FromHours(1);
+			customOptions.ReportRequestOptions.ReportRequestRetryInitialDelay = TimeSpan.FromHours(1);
+			customOptions.ReportRequestOptions.ReportRequestRetryInterval = TimeSpan.FromHours(1);
 			var reportRequestWithNoRetryPeriodComplete1 = new ReportRequestEntry { AmazonRegion = AmazonRegion.Europe, MerchantId = _merchantId, Id = 3, RequestReportId = null, ReportRequestRetryCount = 0, LastAmazonRequestDate = DateTime.UtcNow.AddMinutes(-61) };
 			var reportRequestWithNoRetryPeriodComplete2 = new ReportRequestEntry { AmazonRegion = AmazonRegion.Europe, MerchantId = _merchantId, Id = 4, RequestReportId = null, ReportRequestRetryCount = 0, LastAmazonRequestDate = DateTime.UtcNow.AddMinutes(-61) };
 
@@ -227,8 +227,8 @@ namespace EasyMWS.Tests.Services
 		{
 			var customOptions = new EasyMwsOptions();
 			var reportRequestWithRequestRetryPeriodIncomplete = new ReportRequestEntry { AmazonRegion = AmazonRegion.Europe, MerchantId = _merchantId, Id = 2, RequestReportId = null, ReportRequestRetryCount = 1, LastAmazonRequestDate = DateTime.UtcNow.AddMinutes(-59) };
-			customOptions.ReportRequestRetryInitialDelay = TimeSpan.FromMinutes(60);
-			customOptions.ReportRequestRetryInterval = TimeSpan.FromMinutes(1);
+			customOptions.ReportRequestOptions.ReportRequestRetryInitialDelay = TimeSpan.FromMinutes(60);
+			customOptions.ReportRequestOptions.ReportRequestRetryInterval = TimeSpan.FromMinutes(1);
 			var reportRequestWithNoRetryPeriodComplete1 = new ReportRequestEntry { AmazonRegion = AmazonRegion.Europe, MerchantId = _merchantId, Id = 3, RequestReportId = null, ReportRequestRetryCount = 1, LastAmazonRequestDate = DateTime.UtcNow.AddMinutes(-61) };
 			var reportRequestWithNoRetryPeriodComplete2 = new ReportRequestEntry { AmazonRegion = AmazonRegion.Europe, MerchantId = _merchantId, Id = 4, RequestReportId = null, ReportRequestRetryCount = 1, LastAmazonRequestDate = DateTime.UtcNow.AddMinutes(-61) };
 
@@ -248,9 +248,9 @@ namespace EasyMWS.Tests.Services
 		{
 			var customOptions = new EasyMwsOptions();
 			var reportRequestWithRequestRetryPeriodIncomplete = new ReportRequestEntry { AmazonRegion = AmazonRegion.Europe, MerchantId = _merchantId, Id = 2, RequestReportId = null, ReportRequestRetryCount = 5, LastAmazonRequestDate = DateTime.UtcNow.AddMinutes(-59) };
-			customOptions.ReportRequestRetryInitialDelay = TimeSpan.FromMinutes(1);
-			customOptions.ReportRequestRetryInterval = TimeSpan.FromMinutes(60);
-			customOptions.ReportRequestRetryType = RetryPeriodType.ArithmeticProgression;
+			customOptions.ReportRequestOptions.ReportRequestRetryInitialDelay = TimeSpan.FromMinutes(1);
+			customOptions.ReportRequestOptions.ReportRequestRetryInterval = TimeSpan.FromMinutes(60);
+			customOptions.ReportRequestOptions.ReportRequestRetryType = RetryPeriodType.ArithmeticProgression;
 			var reportRequestWithNoRetryPeriodComplete1 = new ReportRequestEntry { AmazonRegion = AmazonRegion.Europe, MerchantId = _merchantId, Id = 3, RequestReportId = null, ReportRequestRetryCount = 5, LastAmazonRequestDate = DateTime.UtcNow.AddMinutes(-61) };
 			var reportRequestWithNoRetryPeriodComplete2 = new ReportRequestEntry { AmazonRegion = AmazonRegion.Europe, MerchantId = _merchantId, Id = 4, RequestReportId = null, ReportRequestRetryCount = 5, LastAmazonRequestDate = DateTime.UtcNow.AddMinutes(-61) };
 
@@ -280,9 +280,9 @@ namespace EasyMWS.Tests.Services
 				ReportRequestRetryCount = testRequestRetryCount,
 				LastAmazonRequestDate = DateTime.UtcNow.AddMinutes(-61)
 			};
-			customOptions.ReportRequestRetryInitialDelay = TimeSpan.FromMinutes(1);
-			customOptions.ReportRequestRetryInterval = TimeSpan.FromMinutes(minutesBetweenRetries);
-			customOptions.ReportRequestRetryType = RetryPeriodType.GeometricProgression;
+			customOptions.ReportRequestOptions.ReportRequestRetryInitialDelay = TimeSpan.FromMinutes(1);
+			customOptions.ReportRequestOptions.ReportRequestRetryInterval = TimeSpan.FromMinutes(minutesBetweenRetries);
+			customOptions.ReportRequestOptions.ReportRequestRetryType = RetryPeriodType.GeometricProgression;
 			var reportRequestWithNoRetryPeriodComplete1 = new ReportRequestEntry
 			{
 				AmazonRegion = AmazonRegion.Europe,

--- a/src/EasyMWS/EasyMWS/Data/FeedSubmissionEntry.cs
+++ b/src/EasyMWS/EasyMWS/Data/FeedSubmissionEntry.cs
@@ -8,7 +8,7 @@ using Newtonsoft.Json;
 
 namespace MountainWarehouse.EasyMWS.Data
 {
-    public class FeedSubmissionEntry
+    public class FeedSubmissionEntry : IRestrictionableInvocationEntry
     {
 	    private string _regionAndType;
 

--- a/src/EasyMWS/EasyMWS/Data/FeedSubmissionEntry.cs
+++ b/src/EasyMWS/EasyMWS/Data/FeedSubmissionEntry.cs
@@ -30,11 +30,12 @@ namespace MountainWarehouse.EasyMWS.Data
         public string LastAmazonFeedProcessingStatus { get; set; }
         public DateTime DateCreated { get; set; }
 
-		#region Serialized callback data necessary to invoke a method with it's argument values.
+		#region Callback data necessary to invoke a method with it's argument values.
 		public string TypeName { get; set; }
 	    public string MethodName { get; set; }
 	    public string Data { get; set; }
 	    public string DataTypeName { get; set; }
+        public string InstanceId { get; set; }
 		#endregion
 
 		#region Data necessary to request a report from amazon.

--- a/src/EasyMWS/EasyMWS/Data/ReportRequestEntry.cs
+++ b/src/EasyMWS/EasyMWS/Data/ReportRequestEntry.cs
@@ -29,18 +29,19 @@ namespace MountainWarehouse.EasyMWS.Data
         public string LastAmazonReportProcessingStatus { get; set; }
 		public DateTime DateCreated { get; set; }
 
-		#region Serialized callback data necessary to invoke a method with it's argument values.
+		#region Callback data necessary to invoke a method with it's argument values.
 
 		public string TypeName { get; set; }
 		public string MethodName { get; set; }
 		public string Data { get; set; }
 		public string DataTypeName { get; set; }
+        public string InstanceId { get; set; }
 
-		#endregion
+        #endregion
 
-		#region Data necessary to request a report from amazon.
+        #region Data necessary to request a report from amazon.
 
-		public AmazonRegion AmazonRegion { get; set; }
+        public AmazonRegion AmazonRegion { get; set; }
 		public string ReportType { get; set; }
 		public string MerchantId { get; set; }
 		public ContentUpdateFrequency ContentUpdateFrequency { get; set; }
@@ -78,7 +79,6 @@ namespace MountainWarehouse.EasyMWS.Data
 			DataTypeName = callback?.DataTypeName;
 			ReportRequestData = reportRequestData;
             LastAmazonReportProcessingStatus = null;
-
         }
 	}
 

--- a/src/EasyMWS/EasyMWS/Data/ReportRequestEntry.cs
+++ b/src/EasyMWS/EasyMWS/Data/ReportRequestEntry.cs
@@ -8,8 +8,8 @@ using Newtonsoft.Json;
 
 namespace MountainWarehouse.EasyMWS.Data
 {
-	public class ReportRequestEntry
-	{
+	public class ReportRequestEntry : IRestrictionableInvocationEntry
+    {
 		private string _regionAndType;
 		[NotMapped]
 		public string RegionAndTypeComputed

--- a/src/EasyMWS/EasyMWS/EasyMWS.csproj
+++ b/src/EasyMWS/EasyMWS/EasyMWS.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>MountainWarehouse.EasyMWS</RootNamespace>
     <AssemblyName>MountainWarehouse.EasyMWS</AssemblyName>
-    <Version>3.6.0</Version>
+    <Version>3.6.1</Version>
     <RepositoryUrl>https://github.com/MountainWarehouse/EasyMWS</RepositoryUrl>
     <PackageProjectUrl>https://github.com/MountainWarehouse/EasyMWS</PackageProjectUrl>
     <PackageTags>Amazon MWS MarketplaceWebService</PackageTags>
@@ -15,8 +15,8 @@
     <Description>EasyMWS is a .NET library that intends to simplify the interaction with the Amazon Marketplace Web Services API.
 It tries to do that by abstracting away the request/check/download cycle for downloading reports / submitting feeds.</Description>
     <PackageLicenseUrl>http://aws.amazon.com/apache2.0</PackageLicenseUrl>
-    <AssemblyVersion>3.6.0.0</AssemblyVersion>
-    <FileVersion>3.6.0.0</FileVersion>
+    <AssemblyVersion>3.6.1.0</AssemblyVersion>
+    <FileVersion>3.6.1.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/EasyMWS/EasyMWS/EasyMWS.csproj
+++ b/src/EasyMWS/EasyMWS/EasyMWS.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>MountainWarehouse.EasyMWS</RootNamespace>
     <AssemblyName>MountainWarehouse.EasyMWS</AssemblyName>
-    <Version>3.5.0</Version>
+    <Version>3.6.0</Version>
     <RepositoryUrl>https://github.com/MountainWarehouse/EasyMWS</RepositoryUrl>
     <PackageProjectUrl>https://github.com/MountainWarehouse/EasyMWS</PackageProjectUrl>
     <PackageTags>Amazon MWS MarketplaceWebService</PackageTags>
@@ -15,8 +15,8 @@
     <Description>EasyMWS is a .NET library that intends to simplify the interaction with the Amazon Marketplace Web Services API.
 It tries to do that by abstracting away the request/check/download cycle for downloading reports / submitting feeds.</Description>
     <PackageLicenseUrl>http://aws.amazon.com/apache2.0</PackageLicenseUrl>
-    <AssemblyVersion>3.5.0.0</AssemblyVersion>
-    <FileVersion>3.5.0.0</FileVersion>
+    <AssemblyVersion>3.6.0.0</AssemblyVersion>
+    <FileVersion>3.6.0.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/EasyMWS/EasyMWS/Factories/Reports/FbaReportsFactory.cs
+++ b/src/EasyMWS/EasyMWS/Factories/Reports/FbaReportsFactory.cs
@@ -168,7 +168,6 @@ namespace MountainWarehouse.EasyMWS.Factories.Reports
 				requestedMarketplaces: requestedMarketplaces,
 				startDate: startDate, endDate: endDate);
 
-		[Obsolete("Some of the parameters for this report may be missing. Report request not verified yet.")]
 		public ReportRequestPropertiesContainer FbaBulkFixStrandedInventoryReport(DateTime? startDate = null,
 			DateTime? endDate = null, IEnumerable<MwsMarketplace> requestedMarketplaces = null)
 			=> ReportGeneratorHelper.GenerateReportRequest("_GET_STRANDED_INVENTORY_LOADER_DATA_",
@@ -176,7 +175,6 @@ namespace MountainWarehouse.EasyMWS.Factories.Reports
 				requestedMarketplaces: requestedMarketplaces,
 				startDate: startDate, endDate: endDate);
 
-		[Obsolete("Some of the parameters for this report may be missing. Report request not verified yet.")]
 		public ReportRequestPropertiesContainer FbaStrandedInventoryReport(DateTime? startDate = null,
 			DateTime? endDate = null, IEnumerable<MwsMarketplace> requestedMarketplaces = null)
 			=> ReportGeneratorHelper.GenerateReportRequest("_GET_STRANDED_INVENTORY_UI_DATA_",
@@ -188,7 +186,6 @@ namespace MountainWarehouse.EasyMWS.Factories.Reports
 
 		#region FBA Payment Reports
 
-		[Obsolete("Some of the parameters for this report may be missing. Report request not verified yet.")]
 		public ReportRequestPropertiesContainer FbaFeePreviewReport(DateTime startDate,
 			DateTime? endDate, IEnumerable<MwsMarketplace> requestedMarketplaces = null)
 		{

--- a/src/EasyMWS/EasyMWS/Helpers/EntryInvocationRestrictionHelper.cs
+++ b/src/EasyMWS/EasyMWS/Helpers/EntryInvocationRestrictionHelper.cs
@@ -1,0 +1,37 @@
+﻿using MountainWarehouse.EasyMWS.Model;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MountainWarehouse.EasyMWS.Helpers
+{
+    internal static class EntryInvocationRestrictionHelper<T> where T : IRestrictionableInvocationEntry
+    {
+        internal static List<T> RestrictInvocationToOriginatingClientsIfEnabled(IEnumerable<IRestrictionableInvocationEntry> entries, EasyMwsOptions options)
+        {
+            var invocationRestrictionOptions = options?.CallbackInvocationOptions?.RestrictInvocationToOriginatingInstance;
+            if (invocationRestrictionOptions != null && invocationRestrictionOptions.ForceInvocationByOriginatingInstance == true)
+            {
+                var entriesEligibleForCallbackInvocation = entries.Where(e => e.InstanceId == invocationRestrictionOptions.HashedInstanceId).ToList();
+
+                if (invocationRestrictionOptions.AllowInvocationByAnyInstanceIfInvocationFailedLimitReached)
+                {
+                    // allow any client to attempt callback invocation if the configured amount of invocation failures have happened
+
+                    var entriesWithInvocationFailureLimitReached = entries.Where(e => 
+                        e.InvokeCallbackRetryCount >= invocationRestrictionOptions.InvocationFailuresLimit && 
+                        e.InstanceId != invocationRestrictionOptions.HashedInstanceId).ToList();
+                    entriesEligibleForCallbackInvocation.AddRange(entriesWithInvocationFailureLimitReached);
+
+                    return entriesEligibleForCallbackInvocation.Select(e => (T)e).ToList();
+                }
+                else
+                {
+                    // restrict callback invocation to clients matching the current hashedInstanceId
+                    return entriesEligibleForCallbackInvocation.Select(e => (T)e).ToList();
+                }
+            }
+
+            return entries.Select(e => (T)e).ToList();
+        }
+    }
+}

--- a/src/EasyMWS/EasyMWS/Helpers/InstanceIdHelper.cs
+++ b/src/EasyMWS/EasyMWS/Helpers/InstanceIdHelper.cs
@@ -7,12 +7,15 @@ namespace MountainWarehouse.EasyMWS.Helpers
 {
     internal static class InstanceIdHelper
     {
-        internal static string GetInstanceIdHash(EasyMwsOptions options)
+        /// <summary>
+        /// If customInstanceId is NullOrEmpty then the instanceId will be considered to be Environment.MachineName
+        /// </summary>
+        internal static string GetInstanceIdHash(string customInstanceId)
         {
             string instanceId = null;
             try
             {
-                instanceId = options?.CallbackInvocationOptions?.RestrictInvocationToOriginatingInstance?.CustomInstanceId ?? Environment.MachineName;
+                instanceId = string.IsNullOrEmpty(customInstanceId) ? Environment.MachineName : customInstanceId;
             }
             catch (InvalidOperationException)
             {
@@ -23,6 +26,8 @@ namespace MountainWarehouse.EasyMWS.Helpers
 
         private static string ComputeHash(string source)
         {
+            if (string.IsNullOrEmpty(source)) return null;
+
             using (SHA256 sha256Hash = SHA256.Create())
             {
                 byte[] bytes = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(source));

--- a/src/EasyMWS/EasyMWS/Helpers/InstanceIdHelper.cs
+++ b/src/EasyMWS/EasyMWS/Helpers/InstanceIdHelper.cs
@@ -1,0 +1,39 @@
+﻿using MountainWarehouse.EasyMWS.Model;
+using System;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace MountainWarehouse.EasyMWS.Helpers
+{
+    internal static class InstanceIdHelper
+    {
+        internal static string GetInstanceIdHash(EasyMwsOptions options)
+        {
+            string instanceId = null;
+            try
+            {
+                instanceId = options?.CallbackInvocationOptions?.RestrictInvocationToOriginatingInstance?.CustomInstanceId ?? Environment.MachineName;
+            }
+            catch (InvalidOperationException)
+            {
+                instanceId = null;
+            }
+            return ComputeHash(instanceId);
+        }
+
+        private static string ComputeHash(string source)
+        {
+            using (SHA256 sha256Hash = SHA256.Create())
+            {
+                byte[] bytes = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(source));
+
+                StringBuilder builder = new StringBuilder();
+                for (int i = 0; i < bytes.Length; i++)
+                {
+                    builder.Append(bytes[i].ToString("x2"));
+                }
+                return builder.ToString();
+            }
+        }
+    }
+}

--- a/src/EasyMWS/EasyMWS/Migrations/20190426141842_AddInstanceIdToEntryTables.Designer.cs
+++ b/src/EasyMWS/EasyMWS/Migrations/20190426141842_AddInstanceIdToEntryTables.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MountainWarehouse.EasyMWS.Data;
 
 namespace MountainWarehouse.EasyMWS.Migrations
 {
     [DbContext(typeof(EasyMwsContext))]
-    partial class EasyMwsContextModelSnapshot : ModelSnapshot
+    [Migration("20190426141842_AddInstanceIdToEntryTables")]
+    partial class AddInstanceIdToEntryTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/EasyMWS/EasyMWS/Migrations/20190426141842_AddInstanceIdToEntryTables.cs
+++ b/src/EasyMWS/EasyMWS/Migrations/20190426141842_AddInstanceIdToEntryTables.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace MountainWarehouse.EasyMWS.Migrations
+{
+    public partial class AddInstanceIdToEntryTables : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "InstanceId",
+                table: "ReportRequestEntries",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "InstanceId",
+                table: "FeedSubmissionEntries",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "InstanceId",
+                table: "ReportRequestEntries");
+
+            migrationBuilder.DropColumn(
+                name: "InstanceId",
+                table: "FeedSubmissionEntries");
+        }
+    }
+}

--- a/src/EasyMWS/EasyMWS/Model/EasyMwsOptions.cs
+++ b/src/EasyMWS/EasyMWS/Model/EasyMwsOptions.cs
@@ -66,12 +66,16 @@ namespace MountainWarehouse.EasyMWS.Model
         public TimeSpan InvokeCallbackRetryInterval { get; set; }
 
         /// <summary>
-		/// Default=false. Invoke the callback method for reports being downloaded from Amazon, even if the report status received from Amazon is DoneNoData, with the report stream argument being null.
+		/// Default=false. Invoke the callback method after a report has been downloaded or after a feed has been submitted, even if the report status received from Amazon is DoneNoData, with the report stream argument being null.
 		/// </summary>
         public bool InvokeCallbackForReportStatusDoneNoData { get; set; }
 
+        public RestrictInvocationToOriginatingInstance RestrictInvocationToOriginatingInstance { get; set; }
+
         public CallbackInvocationOptions(bool useDefaultValues = true)
         {
+            RestrictInvocationToOriginatingInstance = new RestrictInvocationToOriginatingInstance(useDefaultValues);
+
             if (useDefaultValues)
             {
                 InvokeCallbackMaxRetryCount = 5;
@@ -81,6 +85,46 @@ namespace MountainWarehouse.EasyMWS.Model
                 InvokeCallbackForReportStatusDoneNoData = false;
             }
         }
+    }
+
+    /// <summary>
+    /// Options regarding restricting callback invocations by originating clients only.
+    /// </summary>
+    public class RestrictInvocationToOriginatingInstance
+    {
+        public RestrictInvocationToOriginatingInstance(bool useDefaultValues = true)
+        {
+            ForceInvocationByOriginatingInstance = false;
+            AllowInvocationByAnyInstanceIfInvocationFailedLimitReached = false;
+            CustomInstanceId = null;
+            InvocationFailedLimit = 2;
+        }
+
+        /// <summary>
+        /// Default=null. A custom value identifying an EasyMwsClient instance. <para/>
+        /// If set to true then only a client with a matching CustomInstanceId value will be able to invoke a callback for a request originating from a client with the same CustomInstanceId.<para/>
+        /// If the Default value is set, then the instance id will automatically be set to System.Environment.MachineName.<para/>
+        /// If the same CustomInstanceId value is specified for multiple clients sharing the same persistence location (e.g. database), then any of those clients will be able to invoke callbacks for requests submitted from clients with that CustomInstanceId.
+        /// </summary>
+        public string CustomInstanceId { get; set; }
+
+        /// <summary>
+        /// Default=false. After a report has been downloaded or after a feed has been submitted, try to invoke the callback method but restrict the source of the invocation to the instance from where the initial request originated.<para/>
+        /// If AllowInvocationByAnyInstanceIfInvocationFailedLimitReached is false, then callbacks can always ONLY be invoked by the instance from where the request originated.<para/>
+        /// </summary>
+        public bool ForceInvocationByOriginatingInstance { get; set; }
+
+        /// <summary>
+        /// Default=false. After a report has been downloaded or after a feed has been submitted, if the callback invocation attempts fails for InvocationFailedLimit times, then allow the invocation to be made from any client instance.<para/>
+        /// This is only being used if ForceInvocationByOriginatingInstance is true.
+        /// </summary>
+        public bool AllowInvocationByAnyInstanceIfInvocationFailedLimitReached { get; set; }
+
+        /// <summary>
+        /// Default=2. Specify the number of callback invocation failures allowed to happen before attempting to invoke a callback from Any instance.<para/>
+        /// This is only being used if AllowInvocationByAnyInstanceIfInvocationFailedLimitReached is true.
+        /// </summary>
+        public int InvocationFailedLimit { get; set; }
     }
 
     /// <summary>

--- a/src/EasyMWS/EasyMWS/Model/EasyMwsOptions.cs
+++ b/src/EasyMWS/EasyMWS/Model/EasyMwsOptions.cs
@@ -7,90 +7,16 @@ namespace MountainWarehouse.EasyMWS.Model
 	/// </summary>
     public class EasyMwsOptions
     {
-		/// <summary>
-		/// Default=3.hen receiving a _CANCELLED_ or unhandled processing status from amazon for a feed submitted for processing, specify how many times to retry submitting the same feed.
-		/// </summary>
-		public int FeedProcessingMaxRetryCount { get; set; }
+        internal const int WorstCaseScenarioRetryInitialDelay = 5;
+        internal const int WorstCaseScenarioRetryInterval = 10;
+        internal const RetryPeriodType ExponentialRetryPeriodIncrease = RetryPeriodType.GeometricProgression;
+        internal const RetryPeriodType ConstantRetryPeriod = RetryPeriodType.ArithmeticProgression;
+        internal const int AmazonServiceRequestRetryCount = 4;
+        internal const int AmazonRequestRequeueLimit = 2;
 
-	    /// <summary>
-		/// Default=3. When receiving a _CANCELLED_ or unhandled processing status from amazon for a report queued for request, specify how many times to retry requesting the same report from amazon. 
-		/// </summary>
-		public int ReportProcessingMaxRetryCount { get; set; }
-
-	    /// <summary>
-		/// Default=5. When attempting to invoke a callback method after a report has been downloaded or after a feed has been submitted, and the callback invocation fails, specify how many times to retry the invocation.
-		/// </summary>
-		public int InvokeCallbackMaxRetryCount { get; set; }
-
-		/// <summary>
-		///  Default=ArithmeticProgression. When attempting to invoke a callback method after a report has been downloaded or after a feed has been submitted, and the callback invocation fails, specify the time series type for invocation retries.
-		/// </summary>
-		public RetryPeriodType InvokeCallbackRetryPeriodType { get; set; }
-
-		/// <summary>
-		/// Default=30minutes. When attempting to invoke a callback method after a report has been downloaded or after a feed has been submitted, and the callback invocation fails, specify the interval between retries. 
-		/// </summary>
-		public TimeSpan InvokeCallbackRetryInterval { get; set; }
-
-	    /// <summary>
-		/// Default=4. When attempting to download a report from amazon but the attempt fails, specify how many times to retry the download.
-		/// </summary>
-		public int ReportDownloadMaxRetryCount { get; set; }
-
-		/// <summary>
-		/// Default=GeometricProgression. When attempting to download a report from amazon but the attempt fails, specify the time series type for download retries.
-		/// </summary>
-		public RetryPeriodType ReportDownloadRetryType { get; set; }
-
-		/// <summary>
-		/// Default=30minutes.When attempting to download a report from amazon but the attempt fails, specify the initial delay awaited before the first download retry is performed.
-		/// </summary>
-		public TimeSpan ReportDownloadRetryInitialDelay { get; set; }
-
-		/// <summary>
-		///  Default=1hour.When attempting to download a report from amazon but the attempt fails, specify the time-step used to calculate how often download retries will be performed. 
-		/// </summary>
-		public TimeSpan ReportDownloadRetryInterval { get; set; }
-
-	    /// <summary>
-		/// Default=4. When requesting a report from amazon fails, specify how many times to retry the same request.
-		/// </summary>
-	    public int ReportRequestMaxRetryCount { get; set; }
-
-	    /// <summary>
-		/// Default=GeometricProgression. When requesting a report from amazon fails, specify the time series type for request retries.
-		/// </summary>
-		public RetryPeriodType ReportRequestRetryType { get; set; }
-
-		/// <summary>
-		/// Default=30minutes. When requesting a report from amazon fails, specify the initial delay awaited before the first request retry is performed.
-		/// </summary>
-		public TimeSpan ReportRequestRetryInitialDelay { get; set; }
-
-		/// <summary>
-		/// Default=1hour. When requesting a report from amazon fails, specify the time-step used to calculate how often request retries will be performed. 
-		/// </summary>
-		public TimeSpan ReportRequestRetryInterval { get; set; }
-
-		/// <summary>
-		/// Default=4. When requesting a FeedSubmission from amazon fails, specify how many times to retry the same request.
-		/// </summary>
-		public int FeedSubmissionMaxRetryCount { get; set; }
-
-		/// <summary>
-		/// Default=GeometricProgression. When requesting a FeedSubmission from amazon fails, specify the time series type for request retries.
-		/// </summary>
-		public RetryPeriodType FeedSubmissionRetryType { get; set; }
-
-		/// <summary>
-		/// Default=30minutes. When requesting a FeedSubmission from amazon fails, specify the initial delay awaited before the first request retry is performed.
-		/// </summary>
-		public TimeSpan FeedSubmissionRetryInitialDelay { get; set; }
-
-		/// <summary>
-		/// Default=1hour. When requesting a FeedSubmission from amazon fails, specify the time-step used to calculate how often request retries will be performed. 
-		/// </summary>
-		public TimeSpan FeedSubmissionRetryInterval { get; set; }
+        public CallbackInvocationOptions CallbackInvocationOptions { get; set; }
+        public ReportRequestOptions ReportRequestOptions { get; set; }
+        public FeedSubmissionOptions FeedSubmissionOptions { get; set; }
 
 		/// <summary>
 		/// Default=null. If a connection string is specified using this option, the EasyMws local db will run against this connection string, ignoring any connection string contained in a configuration file.<para/>
@@ -98,88 +24,207 @@ namespace MountainWarehouse.EasyMWS.Model
 		/// </summary>
 		public string LocalDbConnectionStringOverride { get; set; }
 
-		/// <summary>
-		/// Default=1day. Sets the expiration period of report download request entries. If a request entry is not completed before the expiration period, then it is automatically removed from queue.
-		/// </summary>
-	    public TimeSpan ReportDownloadRequestEntryExpirationPeriod { get; set; }
+        /// <summary>
+        /// Returns a new instance of EasyMwsOptions populated with the default values. The configuration is identical to that returned by public the Defaults() static method.<para/>
+        /// LocalDbConnectionStringOverride = null
+        /// </summary>
+        public EasyMwsOptions(bool useDefaultValues = true)
+        {
+            CallbackInvocationOptions = new CallbackInvocationOptions(useDefaultValues);
+            ReportRequestOptions = new ReportRequestOptions(useDefaultValues);
+            FeedSubmissionOptions = new FeedSubmissionOptions(useDefaultValues);
 
-	    /// <summary>
-	    /// Default=2days. Sets the expiration period of feed submission request entries. If a request entry is not completed before the expiration period, then it is automatically removed from queue.
-	    /// </summary>
-	    public TimeSpan FeedSubmissionRequestEntryExpirationPeriod { get; set; }
+            if (useDefaultValues)
+            {
+                LocalDbConnectionStringOverride = null;
+            }
+        }
+    }
 
-		/// <summary>
+    /// <summary>
+    /// InvokeCallbackMaxRetryCount = 5,<para/>
+    /// InvokeCallbackRetryPeriodType = RetryPeriodType.ArithmeticProgression,<para/>
+    /// InvokeCallbackRetryInterval = TimeSpan.FromMinutes(30),<para/>
+    /// <para/>
+    /// InvokeCallbackForReportStatusDoneNoData = false<para/>
+    /// </summary>
+    public class CallbackInvocationOptions
+    {
+        /// <summary>
+        /// Default=5. When attempting to invoke a callback method after a report has been downloaded or after a feed has been submitted, and the callback invocation fails, specify how many times to retry the invocation.
+        /// </summary>
+        public int InvokeCallbackMaxRetryCount { get; set; }
+
+        /// <summary>
+        ///  Default=ArithmeticProgression. When attempting to invoke a callback method after a report has been downloaded or after a feed has been submitted, and the callback invocation fails, specify the time series type for invocation retries.
+        /// </summary>
+        public RetryPeriodType InvokeCallbackRetryPeriodType { get; set; }
+
+        /// <summary>
+        /// Default=2minutes. When attempting to invoke a callback method after a report has been downloaded or after a feed has been submitted, and the callback invocation fails, specify the interval between retries. 
+        /// </summary>
+        public TimeSpan InvokeCallbackRetryInterval { get; set; }
+
+        /// <summary>
 		/// Default=false. Invoke the callback method for reports being downloaded from Amazon, even if the report status received from Amazon is DoneNoData, with the report stream argument being null.
 		/// </summary>
         public bool InvokeCallbackForReportStatusDoneNoData { get; set; }
 
-        /// <summary>
-        /// Returns a new instance of EasyMwsOptions populated with the default values. The configuration is identical to that returned by public the Defaults() static method.<para/>
-        /// InvokeCallbackMaxRetryCount = 5,<para/>
-        /// InvokeCallbackRetryPeriodType = RetryPeriodType.ArithmeticProgression,<para/>
-        /// InvokeCallbackRetryInterval = TimeSpan.FromMinutes(30),<para/>
-        /// <para/>
-        /// ReportRequestMaxRetryCount = 4,<para/>
-        /// ReportRequestRetryType = RetryPeriodType.GeometricProgression,<para/>
-        /// ReportRequestRetryInitialDelay = TimeSpan.FromMinutes(30),<para/>
-        /// ReportRequestRetryInterval = TimeSpan.FromHours(1),<para/>
-        /// <para/>
-        /// ReportDownloadMaxRetryCount = 4,<para/>
-        /// ReportDownloadRetryType = RetryPeriodType.GeometricProgression,<para/>
-        /// ReportDownloadRetryInitialDelay = TimeSpan.FromMinutes(30),<para/>
-        /// ReportDownloadRetryInterval = TimeSpan.FromHours(1),<para/>
-        /// <para/>
-        /// ReportProcessingMaxRetryCount = 3<para/>
-        /// FeedProcessingMaxRetryCount = 3<para/>
-        /// <para/>
-        /// FeedSubmissionMaxRetryCount = 3,<para/>
-        /// FeedSubmissionRetryType = RetryPeriodType.GeometricProgression,<para/>
-        /// FeedSubmissionRetryInitialDelay = TimeSpan.FromMinutes(30),<para/>
-        /// FeedSubmissionRetryInterval = TimeSpan.FromHours(1),<para/>
-        /// <para/>
-        /// ReportDownloadRequestEntryExpirationPeriod = TimeSpan.FromDays(1),<para/>
-        /// FeedSubmissionRequestEntryExpirationPeriod = TimeSpan.FromDays(2),<para/>
-        /// <para/>
-        /// InvokeCallbackForReportStatusDoneNoData = false<para/>
-        /// </summary>
-        public EasyMwsOptions(bool useDefaultValues = true)
+        public CallbackInvocationOptions(bool useDefaultValues = true)
         {
             if (useDefaultValues)
             {
-                const int worstCaseScenarioRetryInitialDelay = 10;
-                const int worstCaseScenarioRetryInterval = 1;
-                const RetryPeriodType exponentialRetryPeriodIncrease = RetryPeriodType.GeometricProgression;
-                const RetryPeriodType constantRetryPeriod = RetryPeriodType.ArithmeticProgression;
-                const int amazonServiceRequestRetryCount = 4;
-                const int amazonRequestRequeueLimit = 3;
-
-
                 InvokeCallbackMaxRetryCount = 5;
-                InvokeCallbackRetryPeriodType = constantRetryPeriod;
-                InvokeCallbackRetryInterval = TimeSpan.FromMinutes(30);
-
-                ReportRequestMaxRetryCount = amazonServiceRequestRetryCount;
-                ReportRequestRetryType = exponentialRetryPeriodIncrease;
-                ReportRequestRetryInitialDelay = TimeSpan.FromMinutes(worstCaseScenarioRetryInitialDelay);
-                ReportRequestRetryInterval = TimeSpan.FromHours(worstCaseScenarioRetryInterval);
-
-                ReportDownloadMaxRetryCount = amazonServiceRequestRetryCount;
-                ReportDownloadRetryType = exponentialRetryPeriodIncrease;
-                ReportDownloadRetryInitialDelay = TimeSpan.FromMinutes(worstCaseScenarioRetryInitialDelay);
-                ReportDownloadRetryInterval = TimeSpan.FromHours(worstCaseScenarioRetryInterval);
-
-                ReportProcessingMaxRetryCount = amazonRequestRequeueLimit;
-                FeedProcessingMaxRetryCount = amazonRequestRequeueLimit;
-
-                FeedSubmissionMaxRetryCount = amazonServiceRequestRetryCount;
-                FeedSubmissionRetryType = exponentialRetryPeriodIncrease;
-                FeedSubmissionRetryInitialDelay = TimeSpan.FromMinutes(worstCaseScenarioRetryInitialDelay);
-                FeedSubmissionRetryInterval = TimeSpan.FromHours(worstCaseScenarioRetryInterval);
-
-                ReportDownloadRequestEntryExpirationPeriod = TimeSpan.FromDays(1);
-                FeedSubmissionRequestEntryExpirationPeriod = TimeSpan.FromDays(2);
+                InvokeCallbackRetryPeriodType = EasyMwsOptions.ConstantRetryPeriod;
+                InvokeCallbackRetryInterval = TimeSpan.FromMinutes(2);
 
                 InvokeCallbackForReportStatusDoneNoData = false;
+            }
+        }
+    }
+
+    /// <summary>
+    /// ReportRequestMaxRetryCount = 4,<para/>
+    /// ReportRequestRetryType = RetryPeriodType.GeometricProgression,<para/>
+    /// ReportRequestRetryInitialDelay = TimeSpan.FromMinutes(30),<para/>
+    /// ReportRequestRetryInterval = TimeSpan.FromHours(1),<para/>
+    /// <para/>
+    /// ReportDownloadMaxRetryCount = 4,<para/>
+    /// ReportDownloadRetryType = RetryPeriodType.GeometricProgression,<para/>
+    /// ReportDownloadRetryInitialDelay = TimeSpan.FromMinutes(30),<para/>
+    /// ReportDownloadRetryInterval = TimeSpan.FromHours(1),<para/>
+    /// <para/>
+    /// ReportProcessingMaxRetryCount = 3<para/>
+    /// ReportDownloadRequestEntryExpirationPeriod = TimeSpan.FromDays(1),<para/>
+    /// </summary>
+    public class ReportRequestOptions
+    {
+        /// <summary>
+		/// Default=3. When receiving a _CANCELLED_ or unhandled processing status from amazon for a report queued for request, specify how many times to retry requesting the same report from amazon. 
+		/// </summary>
+		public int ReportProcessingMaxRetryCount { get; set; }
+
+
+        /// <summary>
+        /// Default=4. When attempting to download a report from amazon but the attempt fails, specify how many times to retry the download.
+        /// </summary>
+        public int ReportDownloadMaxRetryCount { get; set; }
+
+        /// <summary>
+        /// Default=GeometricProgression. When attempting to download a report from amazon but the attempt fails, specify the time series type for download retries.
+        /// </summary>
+        public RetryPeriodType ReportDownloadRetryType { get; set; }
+
+        /// <summary>
+        /// Default=5minutes.When attempting to download a report from amazon but the attempt fails, specify the initial delay awaited before the first download retry is performed.
+        /// </summary>
+        public TimeSpan ReportDownloadRetryInitialDelay { get; set; }
+
+        /// <summary>
+        ///  Default=10minutes.When attempting to download a report from amazon but the attempt fails, specify the time-step used to calculate how often download retries will be performed. 
+        /// </summary>
+        public TimeSpan ReportDownloadRetryInterval { get; set; }
+
+        /// <summary>
+        /// Default=4. When requesting a report from amazon fails, specify how many times to retry the same request.
+        /// </summary>
+        public int ReportRequestMaxRetryCount { get; set; }
+
+        /// <summary>
+        /// Default=GeometricProgression. When requesting a report from amazon fails, specify the time series type for request retries.
+        /// </summary>
+        public RetryPeriodType ReportRequestRetryType { get; set; }
+
+        /// <summary>
+        /// Default=5minutes. When requesting a report from amazon fails, specify the initial delay awaited before the first request retry is performed.
+        /// </summary>
+        public TimeSpan ReportRequestRetryInitialDelay { get; set; }
+
+        /// <summary>
+        /// Default=10minutes. When requesting a report from amazon fails, specify the time-step used to calculate how often request retries will be performed. 
+        /// </summary>
+        public TimeSpan ReportRequestRetryInterval { get; set; }
+
+        /// <summary>
+		/// Default=1day. Sets the expiration period of report download request entries. If a request entry is not completed before the expiration period, then it is automatically removed from queue.
+		/// </summary>
+	    public TimeSpan ReportDownloadRequestEntryExpirationPeriod { get; set; }
+
+        public ReportRequestOptions(bool useDefaultValues = true)
+        {
+            if (useDefaultValues)
+            {
+                ReportRequestMaxRetryCount = EasyMwsOptions.AmazonServiceRequestRetryCount;
+                ReportRequestRetryType = EasyMwsOptions.ExponentialRetryPeriodIncrease;
+                ReportRequestRetryInitialDelay = TimeSpan.FromMinutes(EasyMwsOptions.WorstCaseScenarioRetryInitialDelay);
+                ReportRequestRetryInterval = TimeSpan.FromMinutes(EasyMwsOptions.WorstCaseScenarioRetryInterval);
+
+                ReportDownloadMaxRetryCount = EasyMwsOptions.AmazonServiceRequestRetryCount;
+                ReportDownloadRetryType = EasyMwsOptions.ExponentialRetryPeriodIncrease;
+                ReportDownloadRetryInitialDelay = TimeSpan.FromMinutes(EasyMwsOptions.WorstCaseScenarioRetryInitialDelay);
+                ReportDownloadRetryInterval = TimeSpan.FromMinutes(EasyMwsOptions.WorstCaseScenarioRetryInterval);
+
+                ReportProcessingMaxRetryCount = EasyMwsOptions.AmazonRequestRequeueLimit;
+                ReportDownloadRequestEntryExpirationPeriod = TimeSpan.FromDays(1);
+            }
+        }
+    }
+
+    /// <summary>
+    /// FeedProcessingMaxRetryCount = 3<para/>
+    /// <para/>
+    /// FeedSubmissionMaxRetryCount = 3,<para/>
+    /// FeedSubmissionRetryType = RetryPeriodType.GeometricProgression,<para/>
+    /// FeedSubmissionRetryInitialDelay = TimeSpan.FromMinutes(30),<para/>
+    /// FeedSubmissionRetryInterval = TimeSpan.FromHours(1),<para/>
+    /// FeedSubmissionRequestEntryExpirationPeriod = TimeSpan.FromDays(2),<para/>
+    /// </summary>
+    public class FeedSubmissionOptions
+    {
+        /// <summary>
+        /// Default=3. When receiving a _CANCELLED_ or unhandled processing status from amazon for a feed submitted for processing, specify how many times to retry submitting the same feed.
+        /// </summary>
+        public int FeedProcessingMaxRetryCount { get; set; }
+
+
+        /// <summary>
+        /// Default=4. When requesting a FeedSubmission from amazon fails, specify how many times to retry the same request.
+        /// </summary>
+        public int FeedSubmissionMaxRetryCount { get; set; }
+
+        /// <summary>
+        /// Default=GeometricProgression. When requesting a FeedSubmission from amazon fails, specify the time series type for request retries.
+        /// </summary>
+        public RetryPeriodType FeedSubmissionRetryType { get; set; }
+
+        /// <summary>
+        /// Default=5minutes. When requesting a FeedSubmission from amazon fails, specify the initial delay awaited before the first request retry is performed.
+        /// </summary>
+        public TimeSpan FeedSubmissionRetryInitialDelay { get; set; }
+
+        /// <summary>
+        /// Default=10minutes. When requesting a FeedSubmission from amazon fails, specify the time-step used to calculate how often request retries will be performed. 
+        /// </summary>
+        public TimeSpan FeedSubmissionRetryInterval { get; set; }
+        /// <summary>
+        /// Default=2days. Sets the expiration period of feed submission request entries. If a request entry is not completed before the expiration period, then it is automatically removed from queue.
+        /// </summary>
+        public TimeSpan FeedSubmissionRequestEntryExpirationPeriod { get; set; }
+
+        public FeedSubmissionOptions(bool useDefaultValues = true)
+        {
+            
+            if (useDefaultValues)
+            {
+                FeedProcessingMaxRetryCount = EasyMwsOptions.AmazonRequestRequeueLimit;
+
+                FeedSubmissionMaxRetryCount = EasyMwsOptions.AmazonServiceRequestRetryCount;
+                FeedSubmissionRetryType = EasyMwsOptions.ExponentialRetryPeriodIncrease;
+                FeedSubmissionRetryInitialDelay = TimeSpan.FromMinutes(EasyMwsOptions.WorstCaseScenarioRetryInitialDelay);
+                FeedSubmissionRetryInterval = TimeSpan.FromMinutes(EasyMwsOptions.WorstCaseScenarioRetryInterval);
+
+
+                FeedSubmissionRequestEntryExpirationPeriod = TimeSpan.FromDays(2);
             }
         }
     }

--- a/src/EasyMWS/EasyMWS/Model/EasyMwsOptions.cs
+++ b/src/EasyMWS/EasyMWS/Model/EasyMwsOptions.cs
@@ -95,14 +95,17 @@ namespace MountainWarehouse.EasyMWS.Model
     {
         public RestrictInvocationToOriginatingInstance(bool useDefaultValues = true)
         {
-            ForceInvocationByOriginatingInstance = false;
-            AllowInvocationByAnyInstanceIfInvocationFailedLimitReached = false;
-            CustomInstanceId = null;
-            InvocationFailuresLimit = 2;
+            if (useDefaultValues)
+            {
+                ForceInvocationByOriginatingInstance = false;
+                AllowInvocationByAnyInstanceIfInvocationFailedLimitReached = false;
+                CustomInstanceId = null;
+                InvocationFailuresLimit = 2;
+            }
         }
 
         /// <summary>
-        /// Get a hashed value for CustomInstanceId if it has been set, or else a hashed value of Environment.MachineName
+        /// Default=Hash(Environment.MachineName).Get a hashed value for CustomInstanceId if it has been set, or else a hashed value of Environment.MachineName
         /// </summary>
         internal string HashedInstanceId => InstanceIdHelper.GetInstanceIdHash(CustomInstanceId);
 

--- a/src/EasyMWS/EasyMWS/Model/EasyMwsOptions.cs
+++ b/src/EasyMWS/EasyMWS/Model/EasyMwsOptions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using MountainWarehouse.EasyMWS.Helpers;
+using System;
 
 namespace MountainWarehouse.EasyMWS.Model
 {
@@ -97,8 +98,13 @@ namespace MountainWarehouse.EasyMWS.Model
             ForceInvocationByOriginatingInstance = false;
             AllowInvocationByAnyInstanceIfInvocationFailedLimitReached = false;
             CustomInstanceId = null;
-            InvocationFailedLimit = 2;
+            InvocationFailuresLimit = 2;
         }
+
+        /// <summary>
+        /// Get a hashed value for CustomInstanceId if it has been set, or else a hashed value of Environment.MachineName
+        /// </summary>
+        internal string HashedInstanceId => InstanceIdHelper.GetInstanceIdHash(CustomInstanceId);
 
         /// <summary>
         /// Default=null. A custom value identifying an EasyMwsClient instance. <para/>
@@ -115,16 +121,16 @@ namespace MountainWarehouse.EasyMWS.Model
         public bool ForceInvocationByOriginatingInstance { get; set; }
 
         /// <summary>
-        /// Default=false. After a report has been downloaded or after a feed has been submitted, if the callback invocation attempts fails for InvocationFailedLimit times, then allow the invocation to be made from any client instance.<para/>
+        /// Default=false. After a report has been downloaded or after a feed has been submitted, if the callback invocation attempts fails for InvocationFailuresLimit times, then allow the invocation to be made from any client instance.<para/>
         /// This is only being used if ForceInvocationByOriginatingInstance is true.
         /// </summary>
         public bool AllowInvocationByAnyInstanceIfInvocationFailedLimitReached { get; set; }
 
         /// <summary>
-        /// Default=2. Specify the number of callback invocation failures allowed to happen before attempting to invoke a callback from Any instance.<para/>
+        /// Default=2. Specify the inclusive bound for the number of callback invocation failures allowed to happen before attempting to invoke a callback from Any instance.<para/>
         /// This is only being used if AllowInvocationByAnyInstanceIfInvocationFailedLimitReached is true.
         /// </summary>
-        public int InvocationFailedLimit { get; set; }
+        public int InvocationFailuresLimit { get; set; }
     }
 
     /// <summary>

--- a/src/EasyMWS/EasyMWS/Model/IRestrictionableInvocationEntry.cs
+++ b/src/EasyMWS/EasyMWS/Model/IRestrictionableInvocationEntry.cs
@@ -1,0 +1,8 @@
+﻿namespace MountainWarehouse.EasyMWS.Model
+{
+    public interface IRestrictionableInvocationEntry
+    {
+        string InstanceId { get; set; }
+        int InvokeCallbackRetryCount { get; set; }
+    }
+}

--- a/src/EasyMWS/EasyMWS/Processors/FeedProcessor.cs
+++ b/src/EasyMWS/EasyMWS/Processors/FeedProcessor.cs
@@ -115,7 +115,7 @@ namespace MountainWarehouse.EasyMWS.Processors
                     FeedSubmissionRetryCount = 0,
                     FeedSubmissionId = null,
                     FeedType = propertiesContainer.FeedType,
-                    InstanceId = InstanceIdHelper.GetInstanceIdHash(_options),
+                    InstanceId = _options?.CallbackInvocationOptions?.RestrictInvocationToOriginatingInstance?.HashedInstanceId,
                     Details = new FeedSubmissionDetails
 					{
 						FeedContent = ZipHelper.CreateArchiveFromContent(propertiesContainer.FeedContent)

--- a/src/EasyMWS/EasyMWS/Processors/FeedProcessor.cs
+++ b/src/EasyMWS/EasyMWS/Processors/FeedProcessor.cs
@@ -102,20 +102,21 @@ namespace MountainWarehouse.EasyMWS.Processors
 
 				var serializedPropertiesContainer = JsonConvert.SerializeObject(propertiesContainer);
 
-				var feedSubmission = new FeedSubmissionEntry(serializedPropertiesContainer)
-				{
-					IsLocked = false,
-					AmazonRegion = _region,
-					MerchantId = _merchantId,
-					LastSubmitted = DateTime.MinValue,
-					DateCreated = DateTime.UtcNow,
-					IsProcessingComplete = false,
-					HasErrors = false,
-					SubmissionErrorData = null,
-					FeedSubmissionRetryCount = 0,
-					FeedSubmissionId = null,
-					FeedType = propertiesContainer.FeedType,
-					Details = new FeedSubmissionDetails
+                var feedSubmission = new FeedSubmissionEntry(serializedPropertiesContainer)
+                {
+                    IsLocked = false,
+                    AmazonRegion = _region,
+                    MerchantId = _merchantId,
+                    LastSubmitted = DateTime.MinValue,
+                    DateCreated = DateTime.UtcNow,
+                    IsProcessingComplete = false,
+                    HasErrors = false,
+                    SubmissionErrorData = null,
+                    FeedSubmissionRetryCount = 0,
+                    FeedSubmissionId = null,
+                    FeedType = propertiesContainer.FeedType,
+                    InstanceId = InstanceIdHelper.GetInstanceIdHash(_options),
+                    Details = new FeedSubmissionDetails
 					{
 						FeedContent = ZipHelper.CreateArchiveFromContent(propertiesContainer.FeedContent)
 					}

--- a/src/EasyMWS/EasyMWS/Processors/FeedSubmissionProcessor.cs
+++ b/src/EasyMWS/EasyMWS/Processors/FeedSubmissionProcessor.cs
@@ -340,13 +340,13 @@ namespace MountainWarehouse.EasyMWS.Processors
 
 
 		private bool IsMatchForRegionAndMerchantId(FeedSubmissionEntry e) => e.AmazonRegion == _region && e.MerchantId == _merchantId;
-		private bool IsFeedSubmissionRetryCountExceeded(FeedSubmissionEntry e) => e.FeedSubmissionRetryCount > _options.FeedSubmissionMaxRetryCount;
-		private bool IsReportDownloadRetryCountExceeded(FeedSubmissionEntry e) => e.ReportDownloadRetryCount > _options.ReportDownloadMaxRetryCount;
-		private bool IsFeedProcessingRetryCountExceeded(FeedSubmissionEntry e) => e.FeedProcessingRetryCount > _options.FeedProcessingMaxRetryCount;
-		private bool IsCallbackInvocationRetryCountExceeded(FeedSubmissionEntry e) =>e.InvokeCallbackRetryCount > _options.InvokeCallbackMaxRetryCount;
+		private bool IsFeedSubmissionRetryCountExceeded(FeedSubmissionEntry e) => e.FeedSubmissionRetryCount > _options.FeedSubmissionOptions.FeedSubmissionMaxRetryCount;
+		private bool IsReportDownloadRetryCountExceeded(FeedSubmissionEntry e) => e.ReportDownloadRetryCount > _options.ReportRequestOptions.ReportDownloadMaxRetryCount;
+		private bool IsFeedProcessingRetryCountExceeded(FeedSubmissionEntry e) => e.FeedProcessingRetryCount > _options.FeedSubmissionOptions.FeedProcessingMaxRetryCount;
+		private bool IsCallbackInvocationRetryCountExceeded(FeedSubmissionEntry e) =>e.InvokeCallbackRetryCount > _options.CallbackInvocationOptions.InvokeCallbackMaxRetryCount;
 
 		private bool IsExpirationPeriodExceeded(FeedSubmissionEntry feedSubmissionEntry) =>
-			(DateTime.Compare(feedSubmissionEntry.DateCreated, DateTime.UtcNow.Subtract(_options.FeedSubmissionRequestEntryExpirationPeriod)) < 0);
+			(DateTime.Compare(feedSubmissionEntry.DateCreated, DateTime.UtcNow.Subtract(_options.FeedSubmissionOptions.FeedSubmissionRequestEntryExpirationPeriod)) < 0);
 		private bool IsAmazonErrorCodeFatal(string errorCode)
 		{
 			var fatalErrorCodes = new List<string>

--- a/src/EasyMWS/EasyMWS/Processors/ReportProcessor.cs
+++ b/src/EasyMWS/EasyMWS/Processors/ReportProcessor.cs
@@ -130,7 +130,7 @@ namespace MountainWarehouse.EasyMWS.Processors
 
 				var serializedPropertiesContainer = JsonConvert.SerializeObject(propertiesContainer);
 
-				var reportRequest = new ReportRequestEntry(serializedPropertiesContainer)
+                var reportRequest = new ReportRequestEntry(serializedPropertiesContainer)
 				{
 					IsLocked = false,
 					AmazonRegion = _region,
@@ -144,8 +144,9 @@ namespace MountainWarehouse.EasyMWS.Processors
 					ReportDownloadRetryCount = 0,
 					ReportProcessRetryCount = 0,
 					InvokeCallbackRetryCount = 0,
-					ReportType = propertiesContainer.ReportType
-				};
+					ReportType = propertiesContainer.ReportType,
+                    InstanceId = InstanceIdHelper.GetInstanceIdHash(_options),
+                };
 
 				var serializedCallback = _callbackActivator.SerializeCallback(callbackMethod, callbackData);
 				reportRequest.Data = serializedCallback.Data;

--- a/src/EasyMWS/EasyMWS/Processors/ReportProcessor.cs
+++ b/src/EasyMWS/EasyMWS/Processors/ReportProcessor.cs
@@ -145,7 +145,7 @@ namespace MountainWarehouse.EasyMWS.Processors
 					ReportProcessRetryCount = 0,
 					InvokeCallbackRetryCount = 0,
 					ReportType = propertiesContainer.ReportType,
-                    InstanceId = InstanceIdHelper.GetInstanceIdHash(_options),
+                    InstanceId = _options?.CallbackInvocationOptions?.RestrictInvocationToOriginatingInstance?.HashedInstanceId,
                 };
 
 				var serializedCallback = _callbackActivator.SerializeCallback(callbackMethod, callbackData);

--- a/src/EasyMWS/EasyMWS/Processors/ReportProcessor.cs
+++ b/src/EasyMWS/EasyMWS/Processors/ReportProcessor.cs
@@ -80,11 +80,11 @@ namespace MountainWarehouse.EasyMWS.Processors
                     var callback = new Callback(reportEntry.TypeName, reportEntry.MethodName, reportEntry.Data, reportEntry.DataTypeName);
                     MemoryStream report;
 
-                    if (reportEntry.Details == null && reportEntry.LastAmazonReportProcessingStatus == AmazonReportProcessingStatus.DoneNoData && !_options.InvokeCallbackForReportStatusDoneNoData)
+                    if (reportEntry.Details == null && reportEntry.LastAmazonReportProcessingStatus == AmazonReportProcessingStatus.DoneNoData && !_options.CallbackInvocationOptions.InvokeCallbackForReportStatusDoneNoData)
                     {
                         _logger.Info($"An attempt will not be made to invoke a method callback for the following report in queue : {reportEntry.RegionAndTypeComputed}, because AmazonProcessingStatus for this report is _DONE_NO_DATA_ but InvokeCallbackForReportStatusDoneNoData EasyMwsOption is FALSE.");
                     }
-                    else if (reportEntry.Details == null && reportEntry.LastAmazonReportProcessingStatus == AmazonReportProcessingStatus.DoneNoData && _options.InvokeCallbackForReportStatusDoneNoData)
+                    else if (reportEntry.Details == null && reportEntry.LastAmazonReportProcessingStatus == AmazonReportProcessingStatus.DoneNoData && _options.CallbackInvocationOptions.InvokeCallbackForReportStatusDoneNoData)
                     {
                         _logger.Info($"Attempting to perform method callback for the following report in queue : {reportEntry.RegionAndTypeComputed}, but the AmazonProcessingStatus for this report is _DONE_NO_DATA_ therefore the Stream argument will be null at invocation time.");
                         report = null;

--- a/src/EasyMWS/EasyMWS/Processors/RequestReportProcessor.cs
+++ b/src/EasyMWS/EasyMWS/Processors/RequestReportProcessor.cs
@@ -209,7 +209,7 @@ namespace MountainWarehouse.EasyMWS.Processors
 				}
 				else if (reportGenerationInfo.ReportProcessingStatus == AmazonReportProcessingStatus.DoneNoData)
 				{
-                    if (_options.InvokeCallbackForReportStatusDoneNoData)
+                    if (_options.CallbackInvocationOptions.InvokeCallbackForReportStatusDoneNoData)
                     {
                         reportRequestEntry.ReportProcessRetryCount = 0;
                         reportRequestService.Update(reportRequestEntry);
@@ -360,12 +360,12 @@ namespace MountainWarehouse.EasyMWS.Processors
 		    }
 	    }
 	    private bool IsMatchForRegionAndMerchantId(ReportRequestEntry e) => e.AmazonRegion == _region && e.MerchantId == _merchantId;
-	    private bool IsRequestRetryCountExceeded(ReportRequestEntry e) => e.ReportRequestRetryCount > _options.ReportRequestMaxRetryCount;
-	    private bool IsDownloadRetryCountExceeded(ReportRequestEntry e) => e.ReportDownloadRetryCount > _options.ReportDownloadMaxRetryCount;
-	    private bool IsProcessingRetryCountExceeded(ReportRequestEntry e) => e.ReportProcessRetryCount > _options.ReportProcessingMaxRetryCount;
-	    private bool IsCallbackInvocationRetryCountExceeded(ReportRequestEntry e) => e.InvokeCallbackRetryCount > _options.InvokeCallbackMaxRetryCount;
+	    private bool IsRequestRetryCountExceeded(ReportRequestEntry e) => e.ReportRequestRetryCount > _options.ReportRequestOptions.ReportRequestMaxRetryCount;
+	    private bool IsDownloadRetryCountExceeded(ReportRequestEntry e) => e.ReportDownloadRetryCount > _options.ReportRequestOptions.ReportDownloadMaxRetryCount;
+	    private bool IsProcessingRetryCountExceeded(ReportRequestEntry e) => e.ReportProcessRetryCount > _options.ReportRequestOptions.ReportProcessingMaxRetryCount;
+	    private bool IsCallbackInvocationRetryCountExceeded(ReportRequestEntry e) => e.InvokeCallbackRetryCount > _options.CallbackInvocationOptions.InvokeCallbackMaxRetryCount;
 	    private bool IsExpirationPeriodExceeded(ReportRequestEntry reportRequestEntry) =>
-		    (DateTime.Compare(reportRequestEntry.DateCreated, DateTime.UtcNow.Subtract(_options.ReportDownloadRequestEntryExpirationPeriod)) < 0);
+		    (DateTime.Compare(reportRequestEntry.DateCreated, DateTime.UtcNow.Subtract(_options.ReportRequestOptions.ReportDownloadRequestEntryExpirationPeriod)) < 0);
 
 	    private class EntryToDelete : IEquatable<EntryToDelete>
 	    {

--- a/src/EasyMWS/EasyMWS/Services/FeedSubmissionEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/FeedSubmissionEntryService.cs
@@ -120,7 +120,9 @@ namespace MountainWarehouse.EasyMWS.Services
 			var entries = Where(fse => fse.AmazonRegion == region && fse.MerchantId == merchantId
 						   && fse.Details != null && fse.Details.FeedSubmissionReport != null && fse.IsLocked == false).ToList();
 
-			if(entries.Any() && markEntriesAsLocked)
+            entries = EntryInvocationRestrictionHelper<FeedSubmissionEntry>.RestrictInvocationToOriginatingClientsIfEnabled(entries, _options);
+
+            if(entries.Any() && markEntriesAsLocked)
 			{
 				foreach (var entry in entries)
 				{
@@ -133,7 +135,7 @@ namespace MountainWarehouse.EasyMWS.Services
 			return entries;
 		}
 
-		private bool IsFeedInASubmitFeedQueue(FeedSubmissionEntry feedSubmission)
+        private bool IsFeedInASubmitFeedQueue(FeedSubmissionEntry feedSubmission)
 		{
 			return feedSubmission.FeedSubmissionId == null;
 		}

--- a/src/EasyMWS/EasyMWS/Services/FeedSubmissionEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/FeedSubmissionEntryService.cs
@@ -62,8 +62,8 @@ namespace MountainWarehouse.EasyMWS.Services
 			var entry = FirstOrDefault(fse => fse.AmazonRegion == region && fse.MerchantId == merchantId
 			                         && IsFeedInASubmitFeedQueue(fse)
 			                         && RetryIntervalHelper.IsRetryPeriodAwaited(fse.LastSubmitted,
-										 fse.FeedSubmissionRetryCount, _options.FeedSubmissionRetryInitialDelay,
-										 _options.FeedSubmissionRetryInterval, _options.FeedSubmissionRetryType)
+										 fse.FeedSubmissionRetryCount, _options.FeedSubmissionOptions.FeedSubmissionRetryInitialDelay,
+										 _options.FeedSubmissionOptions.FeedSubmissionRetryInterval, _options.FeedSubmissionOptions.FeedSubmissionRetryType)
 									&& fse.IsLocked == false);
 
 			if(entry != null && markEntryAsLocked)
@@ -101,8 +101,8 @@ namespace MountainWarehouse.EasyMWS.Services
 			var entry = FirstOrDefault(fse => fse.AmazonRegion == region && fse.MerchantId == merchantId
 						   && fse.FeedSubmissionId != null && fse.IsProcessingComplete == true
 						   && RetryIntervalHelper.IsRetryPeriodAwaited(fse.LastSubmitted,
-										   fse.ReportDownloadRetryCount, _options.ReportDownloadRetryInitialDelay,
-										   _options.ReportDownloadRetryInterval, _options.ReportDownloadRetryType)
+										   fse.ReportDownloadRetryCount, _options.ReportRequestOptions.ReportDownloadRetryInitialDelay,
+										   _options.ReportRequestOptions.ReportDownloadRetryInterval, _options.ReportRequestOptions.ReportDownloadRetryType)
 						   && fse.IsLocked == false);
 
 			if (entry != null && markEntryAsLocked)

--- a/src/EasyMWS/EasyMWS/Services/ReportRequestEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/ReportRequestEntryService.cs
@@ -123,7 +123,9 @@ namespace MountainWarehouse.EasyMWS.Services
 							   _options.CallbackInvocationOptions.InvokeCallbackRetryInterval, _options.CallbackInvocationOptions.InvokeCallbackRetryInterval,
 							   _options.CallbackInvocationOptions.InvokeCallbackRetryPeriodType) && rre.IsLocked == false).ToList();
 
-			if (entries.Any() && markEntriesAsLocked)
+            entries = EntryInvocationRestrictionHelper<ReportRequestEntry>.RestrictInvocationToOriginatingClientsIfEnabled(entries, _options);
+
+            if (entries.Any() && markEntriesAsLocked)
 			{
 				foreach (var entry in entries)
 				{
@@ -136,7 +138,7 @@ namespace MountainWarehouse.EasyMWS.Services
 			return entries;
 		}
 
-		public void Dispose()
+        public void Dispose()
 		{
 			_reportRequestEntryRepository.Dispose();
 		}

--- a/src/EasyMWS/EasyMWS/Services/ReportRequestEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/ReportRequestEntryService.cs
@@ -62,8 +62,8 @@ namespace MountainWarehouse.EasyMWS.Services
 			var entry = FirstOrDefault(rre => rre.AmazonRegion == region && rre.MerchantId == merchantId
 											 && rre.RequestReportId == null
 											 && RetryIntervalHelper.IsRetryPeriodAwaited(rre.LastAmazonRequestDate, rre.ReportRequestRetryCount,
-									   _options.ReportRequestRetryInitialDelay, _options.ReportRequestRetryInterval,
-									   _options.ReportRequestRetryType)
+                                       _options.ReportRequestOptions.ReportRequestRetryInitialDelay, _options.ReportRequestOptions.ReportRequestRetryInterval,
+									   _options.ReportRequestOptions.ReportRequestRetryType)
 									   && rre.IsLocked == false);
 
 			if (entry != null && markEntryAsLocked)
@@ -82,8 +82,8 @@ namespace MountainWarehouse.EasyMWS.Services
 			var entry = FirstOrDefault(rre => rre.AmazonRegion == region && rre.MerchantId == merchantId
 							 && rre.RequestReportId != null && rre.GeneratedReportId != null && rre.Details == null && rre.LastAmazonReportProcessingStatus != AmazonReportProcessingStatus.DoneNoData
                              && RetryIntervalHelper.IsRetryPeriodAwaited(rre.LastAmazonRequestDate, rre.ReportDownloadRetryCount,
-									   _options.ReportDownloadRetryInitialDelay, _options.ReportDownloadRetryInterval,
-									   _options.ReportDownloadRetryType)
+									   _options.ReportRequestOptions.ReportDownloadRetryInitialDelay, _options.ReportRequestOptions.ReportDownloadRetryInterval,
+									   _options.ReportRequestOptions.ReportDownloadRetryType)
 									   && rre.IsLocked == false);
 
 			if (entry != null && markEntryAsLocked)
@@ -120,8 +120,8 @@ namespace MountainWarehouse.EasyMWS.Services
 			var entries = Where(rre => rre.AmazonRegion == region && rre.MerchantId == merchantId
 							  && (rre.Details != null || rre.LastAmazonReportProcessingStatus == AmazonReportProcessingStatus.DoneNoData)
 							  && RetryIntervalHelper.IsRetryPeriodAwaited(rre.LastAmazonRequestDate, rre.InvokeCallbackRetryCount,
-							   _options.InvokeCallbackRetryInterval, _options.InvokeCallbackRetryInterval,
-							   _options.InvokeCallbackRetryPeriodType) && rre.IsLocked == false).ToList();
+							   _options.CallbackInvocationOptions.InvokeCallbackRetryInterval, _options.CallbackInvocationOptions.InvokeCallbackRetryInterval,
+							   _options.CallbackInvocationOptions.InvokeCallbackRetryPeriodType) && rre.IsLocked == false).ToList();
 
 			if (entries.Any() && markEntriesAsLocked)
 			{


### PR DESCRIPTION
Implementation for issue https://github.com/MountainWarehouse/EasyMWS/issues/82.

Request result callback invocation can now be restricted to the client that initially submitted the request.

This can be controlled using the following EasyMwsOptions group:  EasyMwsOptions.CallbackInvocationOptions.RestrictInvocationToOriginatingInstance