### PR TITLE
Fix bug which can cause feed entries to not get their latest status from amazon

### DIFF
--- a/src/EasyMWS/EasyMWS.Tests/Services/FeedSubmissionEntryServiceTests.cs
+++ b/src/EasyMWS/EasyMWS.Tests/Services/FeedSubmissionEntryServiceTests.cs
@@ -230,15 +230,15 @@ namespace EasyMWS.Tests.Services
 			_feedSubmissionEntries.AddRange(data);
 
 			// Act
-			var listSubmittedFeeds = _feedSubmissionEntryService.GetIdsForSubmittedFeedsFromQueue(_merchantId, _region);
+			var listSubmittedFeeds = _feedSubmissionEntryService.GetAllSubmittedFeedsFromQueue(_merchantId, _region);
 
 			// Assert
 			Assert.AreEqual(2, listSubmittedFeeds.Count());
-			Assert.IsTrue(listSubmittedFeeds.Count(sf => sf == "FeedSubmissionId4" || sf == "FeedSubmissionId5") == 2);
+			Assert.IsTrue(listSubmittedFeeds.Count(sf => sf.FeedSubmissionId == "FeedSubmissionId4" || sf.FeedSubmissionId == "FeedSubmissionId5") == 2);
 		}
 
 		[Test]
-		public void GetAllPendingReportFromQueue_When_ReturnMoreThan20ValidEntriesExist_Then_Only20EntriesAreReturned()
+		public void GetAllPendingReportFromQueue_When_MoreThan20ValidEntriesExist_Then_AllEntriesAreReturned()
 		{
 			var propertiesContainer = new FeedSubmissionPropertiesContainer("testFeedContent", "testFeedType");
 			var serializedPropertiesContainer = JsonConvert.SerializeObject(propertiesContainer);
@@ -267,17 +267,17 @@ namespace EasyMWS.Tests.Services
 				});
 			}
 
-			var expectedNumberOfEntriesToBeReturned = 20;
+			var expectedNumberOfEntriesToBeReturned = _feedSubmissionEntries.Count(_=>_.MerchantId == merchantIdToRequest);
 
 			// Act
-			var listPendingReports = _feedSubmissionEntryService.GetIdsForSubmittedFeedsFromQueue(merchantIdToRequest, AmazonRegion.Europe).ToList();
+			var listPendingReports = _feedSubmissionEntryService.GetAllSubmittedFeedsFromQueue(merchantIdToRequest, AmazonRegion.Europe).ToList();
 
 			// Assert
 			Assert.AreEqual(expectedNumberOfEntriesToBeReturned, listPendingReports.Count());
 
 			for (int i = 0; i < expectedNumberOfEntriesToBeReturned; i++)
 			{
-				Assert.IsTrue(listPendingReports.Contains($"FeedSubmissionId{i}"));
+				Assert.IsTrue(listPendingReports.Select(_=>_.FeedSubmissionId).Contains($"FeedSubmissionId{i}"));
 			}
 		}
 	}

--- a/src/EasyMWS/EasyMWS/Processors/FeedProcessor.cs
+++ b/src/EasyMWS/EasyMWS/Processors/FeedProcessor.cs
@@ -71,7 +71,7 @@ namespace MountainWarehouse.EasyMWS.Processors
 
 			SubmitNextFeedInQueueToAmazon(feedSubmissionService);
 
-			RequestFeedSubmissionStatusesFromAmazon(feedSubmissionService);
+			RequestFeedSubmissionStatusesAllFromAmazon(feedSubmissionService);
 
 			DownloadNextFeedSubmissionResultFromAmazon(feedSubmissionService);
 
@@ -176,20 +176,34 @@ namespace MountainWarehouse.EasyMWS.Processors
 			_feedSubmissionProcessor.SubmitFeedToAmazon(feedSubmissionService, feedSubmission);
 		}
 
-		public void RequestFeedSubmissionStatusesFromAmazon(IFeedSubmissionEntryService feedSubmissionService)
+		public void RequestFeedSubmissionStatusesAllFromAmazon(IFeedSubmissionEntryService feedSubmissionService)
 		{
-			var feedSubmissionIds = feedSubmissionService.GetIdsForSubmittedFeedsFromQueue(_merchantId, _region).ToList();
+			var allFeedSubmissions = feedSubmissionService.GetAllSubmittedFeedsFromQueue(_merchantId, _region).ToList();
+			const int batchSize = 20;
+			var numberOfBatches = allFeedSubmissions.Count / batchSize + 1;
 
-			if (!feedSubmissionIds.Any())
+            for (int batchNumber = 0; batchNumber < numberOfBatches; batchNumber++)
+            {
+				var nextBatchOfEntriesToProcess = allFeedSubmissions.Skip(batchSize * batchNumber).Take(batchSize).ToList();
+				RequestFeedSubmissionStatusesBatchFromAmazon(feedSubmissionService, nextBatchOfEntriesToProcess);
+			}
+		}
+
+		public void RequestFeedSubmissionStatusesBatchFromAmazon(IFeedSubmissionEntryService feedSubmissionService, List<FeedSubmissionEntry> feedSubmissionsBatch)
+		{
+			if (!feedSubmissionsBatch.Any())
 				return;
 
+			feedSubmissionService.LockMultipleEntries(feedSubmissionsBatch, "Amazon status update has started");
+
+			var feedSubmissionIds = feedSubmissionsBatch.Select(_ => _.FeedSubmissionId);
 			var feedSubmissionResults = _feedSubmissionProcessor.RequestFeedSubmissionStatusesFromAmazon(feedSubmissionService, feedSubmissionIds, _merchantId);
 			if (feedSubmissionResults != null)
 			{
 				_feedSubmissionProcessor.QueueFeedsAccordingToProcessingStatus(feedSubmissionService, feedSubmissionResults);
 			}
 
-			_feedSubmissionProcessor.UnlockFeedSubmissionEntries(feedSubmissionService, feedSubmissionIds);
+			feedSubmissionService.UnlockMultipleEntries(feedSubmissionsBatch, "Amazon status update has been completed");
 		}
 
 		public void DownloadNextFeedSubmissionResultFromAmazon(IFeedSubmissionEntryService feedSubmissionService)

--- a/src/EasyMWS/EasyMWS/Processors/FeedSubmissionProcessor.cs
+++ b/src/EasyMWS/EasyMWS/Processors/FeedSubmissionProcessor.cs
@@ -142,20 +142,6 @@ namespace MountainWarehouse.EasyMWS.Processors
 			}
 		}
 
-		public void UnlockFeedSubmissionEntries(IFeedSubmissionEntryService feedSubmissionService, IEnumerable<string> feedSubmissionIds)
-		{
-			foreach (var submissionId in feedSubmissionIds)
-			{
-				var feedSubmissionEntry = feedSubmissionService.FirstOrDefault(fsc => fsc.FeedSubmissionId == submissionId);
-				if (feedSubmissionEntry != null)
-				{
-					feedSubmissionService.Unlock(feedSubmissionEntry, "Unlocking multiple feed submission entries - amazon processing status update has been completed.");
-					feedSubmissionService.Update(feedSubmissionEntry);
-				}
-			}
-			feedSubmissionService.SaveChanges();
-		}
-
 		public List<(string FeedSubmissionId, string FeedProcessingStatus)> RequestFeedSubmissionStatusesFromAmazon(IFeedSubmissionEntryService feedSubmissionService, IEnumerable<string> feedSubmissionIdList, string merchant)
 		{
 			List<(string FeedSubmissionId, string IsProcessingComplete)> GetProcessingStatusesPerSubmissionIdFromResponse(GetFeedSubmissionListResponse response)

--- a/src/EasyMWS/EasyMWS/Processors/IFeedSubmissionProcessor.cs
+++ b/src/EasyMWS/EasyMWS/Processors/IFeedSubmissionProcessor.cs
@@ -19,6 +19,5 @@ namespace MountainWarehouse.EasyMWS.Processors
 		void CleanUpFeedSubmissionQueue(IFeedSubmissionEntryService feedSubmissionService);
 
 		event EventHandler<FeedRequestFailedEventArgs> FeedEntryWasMarkedForDelete;
-		void UnlockFeedSubmissionEntries(IFeedSubmissionEntryService feedSubmissionService, IEnumerable<string> feedSubmissionIds);
 	}
 }

--- a/src/EasyMWS/EasyMWS/Services/FeedSubmissionEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/FeedSubmissionEntryService.cs
@@ -37,6 +37,32 @@ namespace MountainWarehouse.EasyMWS.Services
 			}
 		}
 
+		public void UnlockMultipleEntries(List<FeedSubmissionEntry> entries, string reason)
+        {
+			if (entries.Any())
+			{
+				foreach (var entry in entries)
+				{
+					Unlock(entry, $"Unlocking Multiple FeedSubmission entries - {reason}");
+					Update(entry);
+				}
+				SaveChanges();
+			}
+		}
+
+		public void LockMultipleEntries(List<FeedSubmissionEntry> entries, string reason)
+		{
+			if (entries.Any())
+			{
+				foreach (var entry in entries)
+				{
+					Lock(entry, $"Locking Multiple FeedSubmission entries  - {reason}");
+					Update(entry);
+				}
+				SaveChanges();
+			}
+		}
+
 		public void Unlock(FeedSubmissionEntry entry, string reason)
 		{
 			if (!entry.IsLocked)
@@ -103,25 +129,14 @@ namespace MountainWarehouse.EasyMWS.Services
 		}
 
 
-		public IEnumerable<string> GetIdsForSubmittedFeedsFromQueue(string merchantId, AmazonRegion region, bool markEntriesAsLocked = true)
+		public IEnumerable<FeedSubmissionEntry> GetAllSubmittedFeedsFromQueue(string merchantId, AmazonRegion region, bool markEntriesAsLocked = true)
 		{
 			var entries = 
 				Where(fse => fse.AmazonRegion == region && fse.MerchantId == merchantId
 						  && fse.FeedSubmissionId != null && fse.IsProcessingComplete == false && fse.IsLocked == false)
-				.Take(20)
 				.ToList();
 
-			if (entries.Any() && markEntriesAsLocked)
-			{
-				foreach (var entry in entries)
-				{
-					Lock(entry, "Locking multiple feed submission entries - ready for having their amazon processing status updated.");
-					Update(entry);
-				}
-				SaveChanges();
-			}
-
-			return entries.Select(f => f.FeedSubmissionId);
+			return entries;
 		}
 
 		public FeedSubmissionEntry GetNextFromQueueOfProcessingCompleteFeeds(string merchantId, AmazonRegion region, bool markEntryAsLocked = true)

--- a/src/EasyMWS/EasyMWS/Services/IFeedSubmissionEntryService.cs
+++ b/src/EasyMWS/EasyMWS/Services/IFeedSubmissionEntryService.cs
@@ -10,6 +10,8 @@ namespace MountainWarehouse.EasyMWS.Services
 {
     internal interface IFeedSubmissionEntryService
     {
+		void UnlockMultipleEntries(List<FeedSubmissionEntry> entries, string reason);
+		void LockMultipleEntries(List<FeedSubmissionEntry> entries, string reason);
 		void Lock(FeedSubmissionEntry entry, string reason);
 		void Unlock(FeedSubmissionEntry entry, string reason);
 		void Create(FeedSubmissionEntry entry);
@@ -24,7 +26,7 @@ namespace MountainWarehouse.EasyMWS.Services
 	    FeedSubmissionEntry FirstOrDefault(Func<FeedSubmissionEntry, bool> predicate);
 	    FeedSubmissionEntry GetNextFromQueueOfFeedsToSubmit(string merchantId, AmazonRegion region, bool markEntryAsLocked = true);
 
-	    IEnumerable<string> GetIdsForSubmittedFeedsFromQueue(string merchantId, AmazonRegion region, bool markEntriesAsLocked = true);
+	    IEnumerable<FeedSubmissionEntry> GetAllSubmittedFeedsFromQueue(string merchantId, AmazonRegion region, bool markEntriesAsLocked = true);
 
 	    FeedSubmissionEntry GetNextFromQueueOfProcessingCompleteFeeds(string merchantId, AmazonRegion region, bool markEntryAsLocked = true);
 	    IEnumerable<FeedSubmissionEntry> GetAllFromQueueOfFeedsReadyForCallback(string merchantId, AmazonRegion region, bool markEntriesAsLocked = true);


### PR DESCRIPTION

This happens if there are lots of entries in the db which are eligible to get a status update from amazon, but those entries are stuck in _PROGRESS_ status. This is especially visible during an Amazon MWS API outage like the one on 25/26 Nov.